### PR TITLE
Fix broken YUI 3.3.0 URL

### DIFF
--- a/js/editors/libraries.js
+++ b/js/editors/libraries.js
@@ -19,7 +19,7 @@ Libraries.prototype.init = function () {
     yui: {
       text: 'YUI',
       scripts: [
-        { text: 'YUI 3.3.0', url: 'http://ajax.googleapis.com/ajax/libs/yui/3.3.0/build/yuiloader/yuiloader-min.js' },
+        { text: 'YUI 3.3.0', url: 'http://yui.yahooapis.com/3.3.0/build/yui/yui-min.js' },
         { text: 'YUI 2.8.2', url: 'http://ajax.googleapis.com/ajax/libs/yui/2.8.2/build/yuiloader/yuiloader-min.js'}
       ]
     },


### PR DESCRIPTION
The URL for YUI 3.3.0 was a 404. I've fixed it, and also changed it to the YUI CDN, which supports combo handling (the Google CDN doesn't, and for YUI 3 it's pretty important if you want reasonable performance when loading dependencies).
