### PR TITLE
Replace deprecated split() function with preg_split() function. Fixes #101

### DIFF
--- a/app.php
+++ b/app.php
@@ -14,7 +14,7 @@ $home = isset($_COOKIE['home']) ? $_COOKIE['home'] : '';
 //   exit;
 // }
 
-$request = split('/', preg_replace('/^\//', '', preg_replace('/\/$/', '', preg_replace('/\?.*$/', '', $request_uri ))));
+$request = preg_split('/\//', preg_replace('/^\//', '', preg_replace('/\/$/', '', preg_replace('/\?.*$/', '', $request_uri ))));
 
 $action = array_pop($request);
 


### PR DESCRIPTION
A fix for deprecation warnings for PHP 5.3 caused by the deprecated `split()` function
