### PR TITLE
Update jquerymobile style to pull correct css file

### DIFF
--- a/js/editors/libraries.js
+++ b/js/editors/libraries.js
@@ -59,7 +59,7 @@ Libraries.prototype.init = function () {
     jquerymobile : {
       text: 'jQuery Mobile',
       requires: 'http://code.jquery.com/jquery-1.6.4.min.js',
-      style: 'http://code.jquery.com/mobile/1.0b3/jquery.mobile-1.0.min.css',
+      style: 'http://code.jquery.com/mobile/1.0/jquery.mobile-1.0.min.css',
       scripts: [
         { text: 'jQuery Mobile 1.0', url: 'http://code.jquery.com/mobile/1.0/jquery.mobile-1.0.min.js' },
         { text: 'jQuery Mobile 1.0b3', url: 'http://code.jquery.com/mobile/1.0b3/jquery.mobile-1.0b3.min.js' }


### PR DESCRIPTION
This fixes the problem of an incorrect css file being requested when adding jQuery Mobile from the Include dropdown.
