### PR TITLE
Add local config.php file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 logs
 logs/*
-config.php
+config.local.php
+js/jsbin*.js

--- a/config.default.php
+++ b/config.default.php
@@ -1,0 +1,22 @@
+<?php
+// Make a copy of this file and name it config.local.php, then fill in
+// the options with your environment specific settings.
+
+// database settings
+define('DB_NAME', 'jsbin');
+define('DB_USER', 'root');      // Your MySQL username
+define('DB_PASSWORD', '');      // ...and password
+define('DB_HOST', 'localhost'); // 99% chance you won't need to change this value
+
+// change this to suite your offline detection
+define('OFFLINE', is_dir('/Users/'));
+
+define('HOST', 'http://jsbin.dev/');
+
+// if you're running from a subdirectory, change this to the start of the
+// url, i.e. offline.jsbin.com/foobar/ - ROOT would be foobar
+define('ROOT', '/');
+
+// wishing PHP were more like JavaScript...wishing I was able to use Node.js they way I had wanted...
+define('VERSION', OFFLINE ? 'debug' : trim(file_get_contents('VERSION')));
+?>

--- a/config.php
+++ b/config.php
@@ -1,19 +1,4 @@
 <?php
-// database settings
-define('DB_NAME', 'jsbin');
-define('DB_USER', 'root');  // Your MySQL username
-define('DB_PASSWORD', ''); // ...and password
-define('DB_HOST', 'localhost');  // 99% chance you won't need to change this value
-
-// change this to suite your offline detection
-define('OFFLINE', is_dir('/Users/'));
-
-define('HOST', 'http://jsbin.dev/');
-
-// if you're running from a subdirectory, change this to the start of the
-// url, i.e. offline.jsbin.com/foobar/ - ROOT would be foobar
-define('ROOT', '/');
-
-// wishing PHP were more like JavaScript...wishing I was able to use Node.js they way I had wanted...
-define('VERSION', OFFLINE ? 'debug' : trim(file_get_contents('VERSION')));
+// Pull in the local settings. Fallback to the defaults.
+require(file_exists('config.local.php') ? 'config.local.php' : 'config.default.php');
 ?>


### PR DESCRIPTION
It is now possible to create a config.local.php file that will be used
to pull in settings rather than modifying the config.default.php. This
local file is ignored by git.

To create a local file copy the default file into a new one.

```
$ cp config.default.php config.local.php
```

Then edit the settings at will.
