### PR TITLE
fixed the incorrect jquery mobile 1.0.1 url.

### DIFF
--- a/js/editors/libraries.js
+++ b/js/editors/libraries.js
@@ -71,7 +71,7 @@ Libraries.prototype.init = function () {
       style: 'http://code.jquery.com/mobile/latest/jquery.mobile.css',
       scripts: [
         { text: 'jQuery Mobile Latest', url: 'http://code.jquery.com/mobile/latest/jquery.mobile.js' },
-        { text: 'jQuery Mobile 1.0.1', url: 'http://code.jquery.com/mobile/1.0/jquery.mobile-1.0.1.min.js' },
+        { text: 'jQuery Mobile 1.0.1', url: 'http://code.jquery.com/mobile/1.0.1/jquery.mobile-1.0.1.min.js' },
         { text: 'jQuery Mobile 1.1.0rc1', url: 'http://code.jquery.com/mobile/1.1.0-rc.1/jquery.mobile-1.1.0-rc.1.js' }
       ]
     },


### PR DESCRIPTION
fixed the incorrect jquery mobile 1.0.1 url.
from: 
http://code.jquery.com/mobile/1.0/jquery.mobile-1.0.1.min.js
to:
http://code.jquery.com/mobile/1.0.1/jquery.mobile-1.0.1.min.js
