### PR TITLE
QUnit on Testing libraries (Feature/node branch)

### DIFF
--- a/public/js/editors/libraries.js
+++ b/public/js/editors/libraries.js
@@ -121,6 +121,14 @@ var libraries = [
         "group": "Dojo"
     },
     {
+        "url" : [
+            "http://code.jquery.com/qunit/qunit-git.css",
+            "http://code.jquery.com/qunit/qunit-git.js"
+        ],
+        "label": "QUnit",
+        "group": "Testing"
+    },
+    {
         "url": [
             "http://documentcloud.github.com/underscore/underscore-min.js",
             "http://documentcloud.github.com/backbone/backbone-min.js"


### PR DESCRIPTION
I'm adding QUnit cdn hosted code to the libraries list. #194

I didn't find any other tests framework's code released on a official or stable cdn. Most are packages, not the built js files.

I'm not including QUnit version because the live git copy is the only version served by the [host](http://code.jquery.com/).
