### PR TITLE
Add Kendo UI to the library templates

### DIFF
--- a/public/js/editors/libraries.js
+++ b/public/js/editors/libraries.js
@@ -129,11 +129,11 @@ var libraries = [
             "http://code.jquery.com/jquery-1.7.1.min.js",
             "http://cdn.kendostatic.com/2012.2.710/js/kendo.all.min.js"
         ],
-        label: "Kendo UI Q2 2012",
-        group: "Kendo UI"
+        "label": "Kendo UI Q2 2012",
+        "group": "Kendo UI"
     },
     {
-        url: [
+        "url": [
             "http://cdn.kendostatic.com/2012.1.322/styles/kendo.common.min.css",
             "http://cdn.kendostatic.com/2012.1.322/styles/kendo.default.min.css",
             "http://cdn.kendostatic.com/2012.1.322/styles/kendo.dataviz.min.css",
@@ -141,8 +141,8 @@ var libraries = [
             "http://code.jquery.com/jquery-1.7.1.min.js",
             "http://cdn.kendostatic.com/2012.1.322/js/kendo.all.min.js"
         ],
-        label: "Kendo UI Q1 2012",
-        group: "Kendo UI"
+        "label": "Kendo UI Q1 2012",
+        "group": "Kendo UI"
     },
     {
         "url" : [


### PR DESCRIPTION
I've added Q1 and Q2 2012 versions of Kendo UI library to the list available ones. All assets loaded from Kendo UI CDN, excluding jQuery 1.7.1, which is loaded from the jQuery CDN.

I was not able to test it, as I was not able to get jsBin 3 running on my machine, but it should work (famous last words). :)
