### PR TITLE
Turn off JSHint for CoffeeScript, fixes #223

### DIFF
--- a/public/js/chrome/errors.js
+++ b/public/js/chrome/errors.js
@@ -73,6 +73,13 @@ var checkForErrors = function () {
   // exit if the javascript panel isn't visible
   if (!editors.javascript.visible) return;
 
+  // Turn off jshint in for coffeescript
+  if( jsbin.state.processors['javascript'] === 'coffeescript' ) {
+    if( $error.is(':visible') ) $error.hide();
+    $document.trigger('sizeeditors');
+    return;
+  }
+
   var hint = jshint(),
       jshintErrors = JSHINT.data(true),
       errors = '',


### PR DESCRIPTION
Just a small fix, saves someone some work hopefully.

Perhaps it should be turned off for Traceur too?
