### PR TITLE
Replaced usage of split() with explode() in php

### DIFF
--- a/php/app.php
+++ b/php/app.php
@@ -70,12 +70,12 @@ setcookie('_csrf', $csrf, 0, PATH);
 //   exit;
 // }
 
-$request = split('/', preg_replace('/^\//', '', preg_replace('/\/$/', '', preg_replace('/\?.*$/', '', $request_uri ))));
+$request = explode('/', preg_replace('/^\//', '', preg_replace('/\/$/', '', preg_replace('/\?.*$/', '', $request_uri ))));
 
 $action = array_pop($request);
 
 if (stripos($action, '.') !== false) {
-  $parts = split('\.', $action);
+  $parts = explode('\.', $action);
   array_push($request, $parts[0]);
   $action = $parts[1];
 }


### PR DESCRIPTION
Tried running jsbin on PHP 5.8 and saw that split() was deprecated in php 5.3. Replaced this with explode(), which is supposed to be used from here on.
