### PR TITLE
Solving the 'mixed tabs & spaces' warnings... (issue #252)

### DIFF
--- a/public/js/editors/panel.js
+++ b/public/js/editors/panel.js
@@ -10,6 +10,12 @@ var editorModes = {
   less: 'css'
 };
 
+if(jsbin.settings.editor.tabMode === "default") {
+  CodeMirror.keyMap.basic.Tab = undefined;
+} else if(jsbin.settings.editor.tabMode !== "classic") {
+  CodeMirror.keyMap.basic.Tab = "indentMore";
+}
+
 var Panel = function (name, settings) {
   var panel = this,
       showPanelButton = true,
@@ -51,7 +57,6 @@ var Panel = function (name, settings) {
   if (settings.editor) {
     cmSettings = {
       parserfile: [],
-      tabMode: 'shift',
       readOnly: jsbin.state.embed ? 'nocursor' : false,
       dragDrop: false, // we handle it ourselves
       mode: editorModes[panelLanguage],


### PR DESCRIPTION
... by setting the codemirror settings more the way they used to be.

Backstory: in CM 2.2, the handling of tabs changed. The setting
'tabMode' does no longer do anything, and by default, codemirror uses
a tab for indentation. That is why the warnings 'mixed tabs and spaces'
starts to show up from JSHint.

Now, there is no good way of disabling those warnings currently, and i
find having modified versions of libraries in the source rather awkward.

This commit restores the behavior of CodeMirror (to only use spaces for
indentation) back to the way it used to be before the CodeMirror
upgrade. I also tried to consider users with their own settings files,
who modified the tabMode option.
