### PR TITLE
Using 'host' instead of 'hostname', allowing non-standard port numbers 

### DIFF
--- a/public/js/chrome/save.js
+++ b/public/js/chrome/save.js
@@ -167,7 +167,7 @@ function saveCode(method, ajax, ajaxCallback) {
         jsbin.state.revision = data.revision;
 
         $binGroup = $('#history tr[data-url="' + jsbin.getURL() + '"]');
-        edit = data.edit.replace(location.protocol + '//' + window.location.hostname, '') + window.location.search;
+        edit = data.edit.replace(location.protocol + '//' + window.location.host, '') + window.location.search;
         $binGroup.find('td.url a span.first').removeClass('first');
         $binGroup.before('<tr data-url="' + data.url + '/" data-edit-url="' + edit + '"><td class="url"><a href="' + edit + '?live"><span class="first">' + data.code + '/</span>' + data.revision + '/</a></td><td class="created"><a href="' + edit + '" pubdate="' + data.created + '">Just now</a></td><td class="title"><a href="' + edit + '">' + data.title + '</a></td></tr>');
 


### PR DESCRIPTION
Save didn't work so well with my non-standard port number (localhost:8888). 
This commit resolves that issue.
