### PR TITLE
Update YUI to latest version (3.6.0).

### DIFF
--- a/public/js/editors/libraries.js
+++ b/public/js/editors/libraries.js
@@ -91,8 +91,8 @@ var libraries = [
         "group": "Prototype"
     },
     {
-        "url": "http://yui.yahooapis.com/3.5.1/build/yui/yui-min.js",
-        "label": "YUI 3.5.1",
+        "url": "http://yui.yahooapis.com/3.6.0/build/yui/yui-min.js",
+        "label": "YUI 3.6.0",
         "group": "YUI"
     },
     {

--- a/public/js/render/console.js
+++ b/public/js/render/console.js
@@ -384,7 +384,7 @@ var exec = document.getElementById('exec'),
         underscore: 'http://documentcloud.github.com/underscore/underscore-min.js',
         rightjs: 'http://rightjs.org/hotlink/right.js',
         coffeescript: 'http://jashkenas.github.com/coffee-script/extras/coffee-script.js',
-        yui: 'http://yui.yahooapis.com/3.2.0/build/yui/yui-min.js'
+        yui: 'http://yui.yahooapis.com/3.6.0/build/yui/yui-min.js'
     },
     body = document.getElementsByTagName('body')[0],
     logAfter = null,


### PR DESCRIPTION
This updates YUI to the latest version (3.6.0), which was released on August 1, 2012:
http://www.yuiblog.com/blog/2012/08/01/announcing-yui-3-6-0/

I am unsure what `libraries` map in `public/js/render/console.js` is used for, but it had a reference to really old YUI version, so I updated that to 3.6.0 as well.
