### PR TITLE
Fix #343, Firefox menu hover issue.

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -232,6 +232,7 @@ a:hover {
   height: 37px;
   border: 1px solid #CCC;
   outline: none;
+  width: 86px;
 }
 
 iframe.javascript {


### PR DESCRIPTION
Added a width of 86px to the #library select. I'm not sure this is
the most flexible way to do this, but it fixes it.

Tested in Chrome 21 & 24, Firefox 15, Opera 12 & 12.50 and Safari 6
on OSX Mountain Lion.
