### PR TITLE
Improve subdomain handling. Fixes #348

### DIFF
--- a/lib/handlers/bin.js
+++ b/lib/handlers/bin.js
@@ -449,7 +449,7 @@ module.exports = Observable.extend({
     // Insert the subdomain if the request has one. Ideally this should be
     // done by the helper.url() function but it's not currently aware of the
     // request object.
-    if (req.subdomain) {
+    if (req.subdomain && custom[req.subdomain]) {
       root = root.replace('://', '://' + req.subdomain + '.');
     }
 

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -107,11 +107,14 @@ module.exports = {
   // subdomains to load custom config files.
   subdomain: function (app) {
     return function (req, res, next) {
-      var host  = req.header('Host', ''),
-          parts = host.split('.');
+      var apphost = app.set('url host').split(':')[0],
+          host = req.header('Host', ''),
+          offset = host.indexOf(apphost);
 
-      if (parts.length > 2) {
-        req.subdomain = parts.slice(0, -2).join('.');
+      if (offset) {
+        // Slice the host from the subdomain and subtract 1 for
+        // trailing . on the subdomain.
+        req.subdomain = host.slice(0, offset - 1);
       }
       next();
     };


### PR DESCRIPTION
We now detect subdomains by taking anything before the "url host" option rather than assuming the host will always be `x.y`.
