### PR TITLE
Updating Dojo versions, adding easy Dijit use

### DIFF
--- a/public/js/editors/libraries.js
+++ b/public/js/editors/libraries.js
@@ -144,17 +144,26 @@ var libraries = [
         "group": "Dojo"
     },
     {
-        "url": "http://ajax.googleapis.com/ajax/libs/dojo/1.8.0/dijit/themes/claro/claro.css",
+        "url": [
+            "http://ajax.googleapis.com/ajax/libs/dojo/1.8.0/dijit/themes/claro/claro.css",
+            "http://ajax.googleapis.com/ajax/libs/dojo/1.8.0/dojo/dojo.js"
+        ],
         "label": "Dijit 1.8.0 (Claro)",
         "group": "Dijit"
     },
     {
-        "url": "http://ajax.googleapis.com/ajax/libs/dojo/1.7.3/dijit/themes/claro/claro.css",
+        "url": [
+            "http://ajax.googleapis.com/ajax/libs/dojo/1.7.3/dijit/themes/claro/claro.css",
+            "http://ajax.googleapis.com/ajax/libs/dojo/1.7.3/dojo/dojo.js"
+        ],
         "label": "Dijit 1.7.3 (Claro)",
         "group": "Dijit"
     },
     {
-        "url": "http://ajax.googleapis.com/ajax/libs/dojo/1.6.1/dijit/themes/claro/claro.css",
+        "url": [
+            "http://ajax.googleapis.com/ajax/libs/dojo/1.6.1/dijit/themes/claro/claro.css",
+            "http://ajax.googleapis.com/ajax/libs/dojo/1.6.1/dojo/dojo.xd.js"
+        ],
         "label": "Dijit 1.6.1 (Claro)",
         "group": "Dijit"
     },


### PR DESCRIPTION
Dojo versions updated to Dojo 1.6+, as well as a new group for Dojo's UI
system, Dijit, to easily bring in the CSS for the most commonly used theme.
