### PR TITLE
Added BonsaiJS 0.4.latest to list of available libs.

### DIFF
--- a/public/js/editors/libraries.js
+++ b/public/js/editors/libraries.js
@@ -183,7 +183,7 @@ var libraries = [
     },
     {
         "url": "//cdnjs.cloudflare.com/ajax/libs/bonsai/0.4/bonsai.min.js",
-        "label": "Bonsai 0.4.0"
+        "label": "Bonsai 0.4.latest"
     },
     {
         "url": "http://jashkenas.github.com/coffee-script/extras/coffee-script.js",


### PR DESCRIPTION
Added Bonsai hosted on cdnjs.
