### PR TITLE
Add Google Maps API v3 To the Add Library Menu

### DIFF
--- a/public/js/editors/libraries.js
+++ b/public/js/editors/libraries.js
@@ -267,6 +267,10 @@ var libraries = [
             " http://canjs.us/release/latest/can.jquery.js"
         ],
         "label": "CanJS 1.0.7 for jQuery"
+    },
+    {
+        "url": "http://maps.googleapis.com/maps/api/js?sensor=false",
+        "label": "Google Maps API v3 latest"
     }
 ];
 


### PR DESCRIPTION
I added a couple of lines to `libraries.js` so that the Google Maps API v3 will now show up in the "Add LIbrary" menu.
