### PR TITLE
Add Kendo UI Q3.2012 release to list of libraries

### DIFF
--- a/public/js/editors/libraries.js
+++ b/public/js/editors/libraries.js
@@ -167,7 +167,7 @@ var libraries = [
             "http://cdn.kendostatic.com/2012.2.710/styles/kendo.default.min.css",
             "http://cdn.kendostatic.com/2012.2.710/styles/kendo.dataviz.min.css",
             "http://cdn.kendostatic.com/2012.2.710/styles/kendo.mobile.all.min.css",
-            "http://code.jquery.com/jquery-1.8.0.min.js",
+            "http://code.jquery.com/jquery-1.7.2.min.js",
             "http://cdn.kendostatic.com/2012.2.710/js/kendo.all.min.js"
         ],
         "label": "Kendo UI Q2 2012",
@@ -179,7 +179,7 @@ var libraries = [
             "http://cdn.kendostatic.com/2012.1.322/styles/kendo.default.min.css",
             "http://cdn.kendostatic.com/2012.1.322/styles/kendo.dataviz.min.css",
             "http://cdn.kendostatic.com/2012.1.322/styles/kendo.mobile.all.min.css",
-            "http://code.jquery.com/jquery-1.8.0.min.js",
+            "http://code.jquery.com/jquery-1.7.2.min.js",
             "http://cdn.kendostatic.com/2012.1.322/js/kendo.all.min.js"
         ],
         "label": "Kendo UI Q1 2012",


### PR DESCRIPTION
Also fixed the jQuery version for older Kendo UI releases that do not support jQuery 1.8.
