### PR TITLE
Don't compile the JS panel twice.

### DIFF
--- a/public/js/render/console.js
+++ b/public/js/render/console.js
@@ -142,9 +142,6 @@ function post(cmd, blind, response /* passed in when echoing from remote console
 
   if (!internalCommand(cmd)) {
 
-    // Compile the command according the the processor
-    cmd = editors.javascript.processor(cmd);
-
     // Fix console not having iframe
     if (!(sandboxframe && sandboxframe.contentWindow)) {
       // Boo. There must be a nice way to do this.


### PR DESCRIPTION
When the run button was clicked, the JS panel was being compiled (rendered) to get the source out of it, and then again to run it with the compiled source.
