### PR TITLE
Update YUI to the lastest version (3.8.0).

### DIFF
--- a/public/js/editors/libraries.js
+++ b/public/js/editors/libraries.js
@@ -127,8 +127,8 @@ var libraries = [
         "group": "Prototype"
     },
     {
-        "url": "http://yui.yahooapis.com/3.7.3/build/yui/yui-min.js",
-        "label": "YUI 3.7.3",
+        "url": "http://yui.yahooapis.com/3.8.0/build/yui/yui-min.js",
+        "label": "YUI 3.8.0",
         "group": "YUI"
     },
     {

--- a/public/js/render/console.js
+++ b/public/js/render/console.js
@@ -414,7 +414,7 @@ var exec = document.getElementById('exec'),
         underscore: 'http://documentcloud.github.com/underscore/underscore-min.js',
         rightjs: 'http://rightjs.org/hotlink/right.js',
         coffeescript: 'http://jashkenas.github.com/coffee-script/extras/coffee-script.js',
-        yui: 'http://yui.yahooapis.com/3.7.3/build/yui/yui-min.js'
+        yui: 'http://yui.yahooapis.com/3.8.0/build/yui/yui-min.js'
     },
     body = document.getElementsByTagName('body')[0],
     logAfter = null,


### PR DESCRIPTION
This updates YUI to the latest version (3.8.0), which was released on December 12, 2012:
http://www.yuiblog.com/blog/2012/12/12/yui-3-8-0-y-color-templates-and-more/
