### PR TITLE
Use smoothness theme instead of base theme for jQuery UI.

### DIFF
--- a/public/js/editors/libraries.js
+++ b/public/js/editors/libraries.js
@@ -33,7 +33,7 @@ var libraries = [
     },
     {
         "url": [
-            "http://ajax.googleapis.com/ajax/libs/jqueryui/1/themes/base/jquery-ui.css",
+            "http://ajax.googleapis.com/ajax/libs/jqueryui/1/themes/smoothness/jquery-ui.css",
             "http://ajax.googleapis.com/ajax/libs/jquery/1/jquery.min.js",
             "http://ajax.googleapis.com/ajax/libs/jqueryui/1/jquery-ui.min.js"
         ],
@@ -51,7 +51,7 @@ var libraries = [
     },
     {
         "url": [
-            "http://ajax.googleapis.com/ajax/libs/jqueryui/1.10.1/themes/base/jquery-ui.css",
+            "http://ajax.googleapis.com/ajax/libs/jqueryui/1.10.1/themes/smoothness/jquery-ui.css",
             "http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js",
             "http://ajax.googleapis.com/ajax/libs/jqueryui/1.10.1/jquery-ui.min.js"
         ],
@@ -60,7 +60,7 @@ var libraries = [
     },
     {
         "url": [
-            "http://ajax.googleapis.com/ajax/libs/jqueryui/1.9.2/themes/base/jquery-ui.css",
+            "http://ajax.googleapis.com/ajax/libs/jqueryui/1.9.2/themes/smoothness/jquery-ui.css",
             "http://ajax.googleapis.com/ajax/libs/jquery/1.8.2/jquery.min.js",
             "http://ajax.googleapis.com/ajax/libs/jqueryui/1.9.2/jquery-ui.min.js"
         ],
@@ -69,7 +69,7 @@ var libraries = [
     },
     {
         "url": [
-            "http://ajax.googleapis.com/ajax/libs/jqueryui/1.8.24/themes/base/jquery-ui.css",
+            "http://ajax.googleapis.com/ajax/libs/jqueryui/1.8.24/themes/smoothness/jquery-ui.css",
             "http://ajax.googleapis.com/ajax/libs/jquery/1.8.2/jquery.min.js",
             "http://ajax.googleapis.com/ajax/libs/jqueryui/1.8.24/jquery-ui.min.js"
         ],


### PR DESCRIPTION
I just saw [a bug report on Twitter](http://twitter.com/martinpolley/status/313012736021909504) related to the fact that we stopped hosting the base theme on all CDNs in jQuery UI 1.10.2. I've changed all the URLs to use the smoothness theme, which is exactly the same as base.
