### PR TITLE
Update YUI to the latest version: 3.9.1

### DIFF
--- a/public/js/editors/libraries.js
+++ b/public/js/editors/libraries.js
@@ -146,8 +146,8 @@ var libraries = [
         "group": "Prototype"
     },
     {
-        "url": "http://yui.yahooapis.com/3.8.1/build/yui/yui-min.js",
-        "label": "YUI 3.8.1",
+        "url": "http://yui.yahooapis.com/3.9.1/build/yui/yui-min.js",
+        "label": "YUI 3.9.1",
         "group": "YUI"
     },
     {

--- a/public/js/render/console.js
+++ b/public/js/render/console.js
@@ -414,7 +414,7 @@ var exec = document.getElementById('exec'),
         underscore: 'http://documentcloud.github.com/underscore/underscore-min.js',
         rightjs: 'http://rightjs.org/hotlink/right.js',
         coffeescript: 'http://jashkenas.github.com/coffee-script/extras/coffee-script.js',
-        yui: 'http://yui.yahooapis.com/3.8.1/build/yui/yui-min.js'
+        yui: 'http://yui.yahooapis.com/3.9.1/build/yui/yui-min.js'
     },
     body = document.getElementsByTagName('body')[0],
     logAfter = null,


### PR DESCRIPTION
This updates YUI to the latest version (3.9.1), which was released on March 27, 2013:
http://www.yuiblog.com/blog/2013/03/27/yui-3-9-1-released/
