### PR TITLE
Add enyo latest and 2.2.0 to libs

### DIFF
--- a/public/js/editors/libraries.js
+++ b/public/js/editors/libraries.js
@@ -262,6 +262,30 @@ var libraries = [
     },
     {
         "url": [
+            "http://nightly.enyojs.com/latest/enyo-nightly/enyo.css",
+            "http://nightly.enyojs.com/latest/enyo-nightly/enyo.js",
+            "http://nightly.enyojs.com/latest/lib/layout/package.js",
+            "http://nightly.enyojs.com/latest/lib/onyx/package.js",
+            "http://nightly.enyojs.com/latest/lib/g11n/package.js",
+            "http://nightly.enyojs.com/latest/lib/canvas/package.js"
+        ],
+        "label": "Enyo latest",
+        "group": "Enyo"
+    },
+    {
+        "url": [
+            "http://enyojs.com/enyo-2.2.0/enyo.css",
+            "http://enyojs.com/enyo-2.2.0/enyo.js",
+            "http://enyojs.com/enyo-2.2.0/lib/layout/package.js",
+            "http://enyojs.com/enyo-2.2.0/lib/onyx/package.js",
+            "http://enyojs.com/enyo-2.2.0/lib/g11n/package.js",
+            "http://enyojs.com/enyo-2.2.0/lib/canvas/package.js"
+        ],
+        "label": "Enyo 2.2.0",
+        "group": "Enyo"
+    },
+    {
+        "url": [
             "http://documentcloud.github.io/underscore/underscore-min.js",
             "http://documentcloud.github.io/backbone/backbone-min.js"
         ],


### PR DESCRIPTION
Hello,

[Enyo](http://enyojs.com/) is a cross-platform JS framework designed for mobile devices, and is part of the [Open webOS architecture](http://www.openwebosproject.org/docs/architecture).

It is used by companies such as [OpenBravo](http://blog.enyojs.com/post/33181474956/openbravo-selects-enyo) and [xTuple](http://www.xtuple.org/a-shorter-letter-enyo) for their mobile applications.

We're also using it at [Hinnoya](http://www.hinnoya.fr/) for some of our mobile applications. Jsbin being a great open source alternative to jsfiddle, I thought it could be interesting for it to support the Enyo libraries as well.

Kind regards.
