### PR TITLE
Updates Underscore / Backbone library links

### DIFF
--- a/public/js/editors/libraries.js
+++ b/public/js/editors/libraries.js
@@ -286,8 +286,8 @@ var libraries = [
     },
     {
         "url": [
-            "http://documentcloud.github.io/underscore/underscore-min.js",
-            "http://documentcloud.github.io/backbone/backbone-min.js"
+            "http://documentcloud.github.com/underscore/underscore-min.js",
+            "http://documentcloud.github.com/backbone/backbone-min.js"
         ],
         "label": "Backbone latest"
     },
@@ -382,7 +382,7 @@ var libraries = [
         "label": "TwitterLib"
     },
     {
-        "url": "http://documentcloud.github.io/underscore/underscore-min.js",
+        "url": "http://documentcloud.github.com/underscore/underscore-min.js",
         "label": "underscore latest"
     },
     {


### PR DESCRIPTION
The links in the libraries.js were out of date. They are returning a
404. It is possible this is a github issue since the libraries are
hosted via github pages. But using .com vs .io has fixed the problem.
