### PR TITLE
Don't replace console. for window.top.console. when embedded.

### DIFF
--- a/public/js/render/render.js
+++ b/public/js/render/render.js
@@ -133,7 +133,7 @@ function getPreparedCode(nojs) {
   }
 
   // redirect console logged to our custom log while debugging
-  if (re.console.test(source)) {
+  if (re.console.test(source) && !jsbin.embed) {
     var replaceWith = 'window.top.' + (jsbin.panels.panels.console.visible ? '_console.' : 'console.');
     // yes, this code looks stupid, but in fact what it does is look for
     // 'console.' and then checks the position of the code. If it's inside


### PR DESCRIPTION
Addresses #582.

This stops jsbin replacing `console.` for `window.top.console.` in embed mode.

However, I'm suspicious of this breaking something else – it's hard to tell. There are `window.top._console` uses scattered around live.js, and I'm pretty sure these will error too if they ever get used.
