### PR TITLE
Support CSS import from gist.

### DIFF
--- a/public/js/chrome/gist.js
+++ b/public/js/chrome/gist.js
@@ -7,15 +7,18 @@ var Gist = function (id) {
   this.code = {};
 
   analytics.loadGist(id);
-  
+
   iframe.load(function () {
     $('.gist-file', win.body).each(function () {
       var code = [];
-      $('pre .line', this).each(function () { 
+      $('pre .line', this).each(function () {
         code.push($(this).text());
       });
 
-      var type = $('.gist-meta a:first', this).attr('href').substr(-2) == 'js' ? 'javascript' : 'html';
+      var metaHref = $('.gist-meta a:first', this).attr('href');
+      var type = 'html'
+      if (metaHref.substr(-2) == 'js') type = 'javascript';
+      if (metaHref.substr(-3) == 'css') type = 'css';
 
       gist.code[type] = code.join("\n");
     });


### PR DESCRIPTION
Check for css type when importing a gist, fix #590.
