### PR TITLE
Hide frame width in embed mode as it overlays HTML

### DIFF
--- a/public/js/render/live.js
+++ b/public/js/render/live.js
@@ -201,8 +201,10 @@ function renderLivePreview(withalerts) {
         }, 2000);
         $(win).on('resize', function () {
           // clearTimeout(timer);
-          size.show().html(this.innerWidth + 'px');
-          hide();
+          if (!jsbin.embed) {
+            size.show().html(this.innerWidth + 'px');
+            hide();
+          }
         });
 
         win.resizeJSBin = throttle(function () {


### PR DESCRIPTION
When viewing the embedded editor, the width in pixels that is shown overlays the HTML and looks very odd.  In normal edit mode this is not a problem because the width is shown above the HTML.
