### PR TITLE
Update libs

### DIFF
--- a/public/js/editors/libraries.js
+++ b/public/js/editors/libraries.js
@@ -295,7 +295,7 @@ var libraries = [
     },
     {
         "url": [
-            "http://code.jquery.com/jquery.js",
+            "http://ajax.googleapis.com/ajax/libs/jquery/1.9/jquery.min.js",
             "http://cdnjs.cloudflare.com/ajax/libs/ember.js/1.0.0-rc.4/ember.min.js"
         ],
         "label": "Ember.js 1.0.0-rc.4"


### PR DESCRIPTION
Update all libs to latest version
remove http: for work with all protocols
remove some old version lib like `jQuery 1.7.2` and `jQuery 1.6.4`
- `jQuery 2.0.2`
- `jQuery WIP (via git)`
- `jQuery 1.10.1`
- `jQuery 1.8.3`
- `jQuery UI WIP (via git)`
- `jQuery UI latest`
- `jQuery UI 1.10.3`
- `jQuery UI 1.9.2`
- `jQuery Mobile Latest`
- `jQuery Mobile 1.3.1`
- `jQuery Mobile 1.2.1`
- `jQuery Mobile 1.1.2`
- `Bootstrap latest`
- `Prototype latest`
- `Prototype 1.7.1`
- `Prototype 1.6.1.0`
- `script.aculo.us latest`
- `script.aculo.us 1.8.3`
- `YUI 3.10.0`
- `YUI 2.9.0`
- `MooTools latest`
- `MooTools 1.4.5`
- `Dojo latest`
- `Dojo 1.8.4`
- `Dojo 1.7.4`
- `Dijit latest (Claro)`
- `Dijit 1.8.4 (Claro)`
- `Dijit 1.7.4 (Claro)`
- `Kendo UI Q1 2013`
- `Kendo UI Q3 2012`
- `QUnit`
- `Zepto latest`
- `Zepto 1.0`
- `Angular 1.1.5 Unstable`
- `Angular 1.0.7 Stable`
- `Enyo latest`
- `Enyo 2.2.0`
- `Backbone latest`
- `Bonsai 0.4.latest`
- `CoffeeScript`
- `Ember.js 1.0.0-rc.4`
- `ES5 shim 2.0.8`
- `ext-core 3.1.0`
- `Foundation 4.1.6`
- `Handlebars.js 1.0.0`
- `Knockout 2.2.1`
- `Less 1.3.3`
- `lodash 1.2.1`
- `Modernizr 2.6.2`
- `Prefixfree 1.0.7`
- `Processing 1.4.1`
- `Rapha&euml;l 2.1.0`
- `Sammy 0.7.4`
- `Sencha Touch`
- `Traceur`
- `TwitterLib`
- `underscore latest`
- `CanJS for jQuery`
- `Three.js r58`
- `HTML5 shiv`
