### PR TITLE
Adding ability to output ES6 JS blocks for Firefox testing

### DIFF
--- a/public/js/processors/processor.js
+++ b/public/js/processors/processor.js
@@ -331,7 +331,13 @@ var processors = jsbin.processors = (function () {
           return msg + ProjectWriter.write(res);
         }
       });
-    }())
+    }()),
+    
+    'es-harmony': createProcessor({
+      id: 'javascript-1.7',
+      extensions: ['js'],
+      target: 'javascript;version=1.7'
+    })
 
   };
 

--- a/public/js/render/render.js
+++ b/public/js/render/render.js
@@ -71,7 +71,8 @@ function getPreparedCode(nojs) {
       hasHTML = false,
       hasCSS = false,
       hasJS = false,
-      date = new Date();
+      date = new Date(),
+      scriptTarget = undefined;
 
   try {
     source = editors.html.render();
@@ -84,6 +85,7 @@ function getPreparedCode(nojs) {
   if (!nojs) {
     try {
       js = editors.javascript.render();
+      scriptTarget = editors.javascript.processor.target || jsbin.panels.panels.javascript.type;
 
       if (js.trim()) js += '\n\n// created @ ' + two(date.getHours()) + ':' + two(date.getMinutes()) + ':' + two(date.getSeconds());
     } catch (e) {
@@ -128,7 +130,7 @@ function getPreparedCode(nojs) {
 
     // RS: not sure why I ran this in closure, but it means the expected globals are no longer so
     // js = "window.onload = function(){" + js + "\n}\n";
-    var type = jsbin.panels.panels.javascript.type ? ' type="text/' + jsbin.panels.panels.javascript.type + '"' : '';
+    var type = scriptTarget ? ' type="application/' + scriptTarget + '"' : '';
     source += "<script" + type + ">\n" + js + "\n</script>\n" + close;
   }
 

--- a/views/index.html
+++ b/views/index.html
@@ -242,6 +242,7 @@
             <a href="#traceur">Traceur</a>
             <a href="#typescript">TypeScript</a>
             <a href="#convert">Convert to JavaScript</a>
+            <a href="#es-harmony">JavaScript 1.7</a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
This should allow you to create JavaScript jsbin's which output with a different `mimetype` that firefox needs to run ES6 code.

You should be able to put this code in the JS tab and get it to execute:

```
var fn = (x) => x;
console.log(fn(42) == 42);
```

Basically it just outputs the right `type` on the script tag
