### PR TITLE
Fix edit button icon sizing

### DIFF
--- a/public/css/edit.css
+++ b/public/css/edit.css
@@ -30,6 +30,8 @@
 }
 
 #edit-with-js-bin img {
+  width: 16px;
+  height: 16px;
   vertical-align: top;
   border: 0;
   margin: -1px 0 0 3px;

--- a/public/js/render/edit.js
+++ b/public/js/render/edit.js
@@ -13,7 +13,7 @@ function jsbinShowEdit(options) {
   el.id = 'edit-with-js-bin';
   el.href = window.location.pathname + (window.location.pathname.substr(-1) == '/' ? '' : '/') + 'edit';
 
-  el.innerHTML = 'Edit in JS Bin <img src="' + options.root + '/images/favicon.png" width="16" height="16">';
+  el.innerHTML = 'Edit in JS Bin <img src="' + options.root + '/images/favicon.png">';
 
   var over;
   el.onmouseover = function () {


### PR DESCRIPTION
This fix makes it so It's harder to accidentally resize the icon in the "edit with JS Bin"  button.

Without this commit, if someone added these styles to their bin's CSS:

```
a img {
    width: 2em;
    height: 2em;
}
```

...then the icon would look screwy.
