### PR TITLE
wrong order of values in setUser query prevents creating new user 

### DIFF
--- a/lib/db/sqlite.js
+++ b/lib/db/sqlite.js
@@ -257,10 +257,11 @@ module.exports = utils.inherit(Object, {
       params.name,
       params.key,
       params.email,
+      now,
+      now,
+      now,
       params.github_token,
-      now,
-      now,
-      now
+      params.github_id
     ], sql = templates.setUser;
 
     this.connection.run(sql, values, function (err) {


### PR DESCRIPTION
Sql query parameters as defined in lib/db/sql_template.json has github token and id at as last parameter. But, in lib/db/sqlite.json github_token is assigned where there should datetime value in last_login. 
Thus, resulting is error like `SQLITE CONSTRAINTS: ownership.last_login must not be null` on console, if github authentication is not used for login.
This commit attempts to fix that error and enable registering new users again.
