### PR TITLE
Fixed app crash if github.* haven't been set in the config

### DIFF
--- a/lib/github.js
+++ b/lib/github.js
@@ -1,19 +1,7 @@
 var passport       = require('passport'),
     GitHubStrategy = require('passport-github').Strategy;
 
-module.exports = function (options) {
-  /**
-   * Passport configuration
-   */
-
-  passport.serializeUser(function(user, done) {
-    done(null, user);
-  });
-
-  passport.deserializeUser(function(obj, done) {
-    done(null, obj);
-  });
-
+var setup = function(options) {
   passport.use(new GitHubStrategy({
       clientID: options.github.id,
       clientSecret: options.github.secret
@@ -41,8 +29,24 @@ module.exports = function (options) {
       });
     }
   ));
+}
+
+module.exports = function (options) {
+  /**
+   * Passport configuration
+   */
+
+  passport.serializeUser(function(user, done) {
+    done(null, user);
+  });
+
+  passport.deserializeUser(function(obj, done) {
+    done(null, obj);
+  });
+
 
   if (options.github && options.github.id) {
+    setup(options);
     return {
       initialize: function (app) {
         app.use(passport.initialize());


### PR DESCRIPTION
The Passport github module uses options.github.\* before the check to see if they've been set in the config. This causes the app to crash if things aren't configured for github. Fixed.
