### PR TITLE
when archive or unarchive is clicked on Bins under "my Bins", node crashes and throws a error that 'results are not defined'.

### DIFF
--- a/lib/db/sqlite.js
+++ b/lib/db/sqlite.js
@@ -484,7 +484,7 @@ module.exports = utils.inherit(Object, {
       if (err || !this.changes) {
         return fn(err);
       }
-      fn(null, results);
+      fn(null, result);
     });
   },
   isOwnerOf: function (params, fn) {


### PR DESCRIPTION
This happens because of silly spelling mistake
in archiveBin in file lib/db/sqlite.js, see commit.

.
