### PR TITLE
Fix #tip position and layout bug.

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -992,8 +992,10 @@ body.streaming #bin {
   font-size: 13px;
 }
 
-.showtip #bin {
-  bottom: 26px;
+.showtip #bin,
+.showtip #history,
+.showtip #history .preview {
+  top: 69px;
 }
 
 #tip {
@@ -1003,11 +1005,15 @@ body.streaming #bin {
   position: absolute;
   bottom: 0;
   font-size: 14px;
-  line-height: 22px;
+  line-height: 28px;
   background: #fdfece;
+  top: 36px;
+  bottom: auto;
   left: 0;
   right: 0;
   padding: 2px 10px 2px 10px;
+  box-shadow: 0 2px 4px rgba(0,0,0,.2);
+
   -webkit-animation: tip-flash 100ms linear 4 alternate;
   -moz-animation: tip-flash 100ms linear 4 alternate;
   -ms-animation: tip-flash 100ms linear 4 alternate;
@@ -1048,12 +1054,8 @@ body.streaming #bin {
   background: #ff5555;
 }
 
-#tip.notification,
-#tip.error {
-  bottom: auto;
-  top: 34px;
-  line-height: 28px;
-  box-shadow: 0 2px 4px rgba(0,0,0,.2);
+.hideheader.ready #tip {
+  top: 6px;
 }
 
 #tip p {
@@ -2451,6 +2453,12 @@ a.active:hover {
 .hideheader #history,
 .hideheader #history .preview {
   top: 6px;
+}
+
+.showtip .hideheader.ready #bin,
+.showtip .hideheader #history,
+.showtip .hideheader #history .preview {
+  top: 39px;
 }
 
 .hideheader #control:hover {


### PR DESCRIPTION
Related to visual error at #793 screen shot.
Do you have only error and notification ?
If you have other tips mode please define special class.
I move all notification at top and try to fix some issue in layout
If you dont need to display tip at bottom of page please merge this pull request
Or if you want to have it please add `#tip.newclassname` for that position.
I do not think it is necessary
Thank you.
