### PR TITLE
Fix performance when LOTS (1200+) bins in history

### DIFF
--- a/public/js/editors/editors.js
+++ b/public/js/editors/editors.js
@@ -302,12 +302,16 @@ panels.hide = function (panelId) {
       jsbin.panels.focused.$el.focus();
     }
     jsbin.panels.focused.focus();
+  }
+
+  /*
   } else if ($history.length && !$body.hasClass('panelsVisible')) {
     $body.toggleClass('dave', $history.is(':visible'));
     $history.toggle(100);
   } else if ($history.length === 0) {
     // TODO load up the history
   }
+  */
 };
 
 panels.hideAll = function () {

--- a/public/js/editors/panel.js
+++ b/public/js/editors/panel.js
@@ -226,6 +226,7 @@ Panel.prototype = {
   virgin: true,
   visible: false,
   show: function (x) {
+    $document.trigger('history:close');
     // check to see if there's a panel to the left.
     // if there is, take it's size/2 and make this our
     // width
@@ -353,7 +354,10 @@ Panel.prototype = {
 
     $document.trigger('sizeeditors');
     panel.trigger('hide');
-    // }, 110);
+
+    // note: the history:open does first check whether there's an open panels
+    // and if there are, it won't show the history, it'll just ignore the event
+    $document.trigger('history:open');
   },
   toggle: function () {
     (this)[this.visible ? 'hide' : 'show']();

--- a/public/js/render/saved-history-preview.js
+++ b/public/js/render/saved-history-preview.js
@@ -1,6 +1,18 @@
 ;(function () {
   var $body = $('body'),
-      loaded = false;
+      loaded = false,
+      $history; // set in hookUserHistory()
+
+  $document.on('history:open', function () {
+    if ($history && jsbin.panels.getVisible().length === 0) {
+      $history.appendTo('body');
+      $history = null;
+    }
+  }).on('history:close', function () {
+    if ($history === null) {
+      $history = $('#history').detach();
+    }
+  });
 
   var loadList = function () {
     if (loaded) return;
@@ -55,8 +67,8 @@
 
   var hookUserHistory = function () {
     // Loading the HTML from the server may have failed
-    var $history = $('#history');
-    if (!$history.length) return;
+    $history = $('#history').detach();
+    if (!$history.length) return $history;
 
     // Cache some useful elements
     var $iframe = $('iframe', $history),
@@ -142,6 +154,9 @@
       updateLayout($tbodys, false);
     }, 0);
 
+    $document.trigger('history:open');
+
+    return $history;
   };
 
   // inside a ready call because history DOM is rendered *after* our JS to improve load times.


### PR DESCRIPTION
This was causing the open/close panels to be /really/ slow, and I eventually figured out it was due to a large DOM hanging in the background. This should also fix scrollbar from partially appearing when the background history loads.
