### PR TITLE
Handle errors raised by passport-github

### DIFF
--- a/lib/handlers/session.js
+++ b/lib/handlers/session.js
@@ -489,6 +489,21 @@ module.exports = Observable.extend({
         }.bind(this));
       }.bind(this));
     }.bind(this));
-  }
+  },
 
+  // Handle custom errors raised by passport-github when recieving an invalid
+  // code parameter to the callback url eg: /auth/github/callback?code=foo
+  //
+  // This will likely occur if a user refreshes or hits the back button on
+  // an expired url. Here we handle it gracefully with a flash message and a
+  // redirect back to the app.
+  githubCallbackWithError: function (err, req, res, next) {
+    // Handle errors raised by the passport-github module indicated by the
+    // custom ouathError property. For the moment only handle 401 codes and
+    // let others bubble up to the global handler.
+    if (err.oauthError && err.oauthError.statusCode === 401) {
+      return this.respondWithMessage(res, res.flash.ERROR, 'Sorry, looks like that auth code has expired, please try and login again.');
+    }
+    next(err);
+  }
 });

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -145,6 +145,9 @@ module.exports = function (app) {
   app.get('/:bin/:quiet(quiet)?', spike.getStream, binHandler.getBinPreview);
   app.get('/:bin/:rev?/:quiet(quiet)?', spike.getStream, binHandler.getBinPreview);
 
+  // Handle failed auth requests.
+  app.use(sessionHandler.githubCallbackWithError);
+
   // Catch all
   app.use(errorHandler.notFound);
 


### PR DESCRIPTION
Despite being a 401 they currently bubble up to the top level error handler, here we redirect the user back to the app with a friendly flash message. As the commit message says these are likely caused by users hitting the back button or refreshing the browser after auth causing the app to try and process an expired token.

Example url for testing before/after: http://jsbin.com/auth/github/callback?code=expired
