### PR TITLE
Fixing #890 - decodeURIComponent on search string.

### DIFF
--- a/public/js/editors/editors.js
+++ b/public/js/editors/editors.js
@@ -74,10 +74,7 @@ panels.restore = function () {
     // it also strips out prop=value& to avoid bashing the
     // panel name
     
-    // Calls decodeURIComponent twice to capture uses of %252C
-    search = decodeURIComponent(decodeURIComponent(search));
-    
-    toopen = (search || hash).replace(/\b([^&=]*)=([^&=]*)/g, '').replace(/&/g, '').split(',');
+    toopen = decodeURIComponent(search || hash).replace(/\b([^&=]*)=([^&=]*)/g, '').replace(/&/g, '').split(',');
 
     if (toopen.indexOf('output') !== -1) {
       toopen.push('live');


### PR DESCRIPTION
Invoking decodeURIComponent on search string, calls twice to capture %252C case's.

Should the double call be in a utils/helper file instead?
