### PR TITLE
Update to Ember 1.1.1.

### DIFF
--- a/public/custom/emberjs/default.html
+++ b/public/custom/emberjs/default.html
@@ -23,7 +23,7 @@
 
   <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
   <script src="http://builds.emberjs.com/handlebars-1.0.0.js"></script>
-  <script src="http://builds.emberjs.com/tags/v1.1.0/ember.min.js"></script>
+  <script src="http://builds.emberjs.com/tags/v1.1.1/ember.min.js"></script>
 
 </body>
 </html>


### PR DESCRIPTION
1.1.1 fixes a regression with `Ember.Object.create`.
