### PR TITLE
Support proxying over a port

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -58,7 +58,7 @@ if (!process.env.TZ && options.timezone) {
 
   // if we're running from the bin/jsbin file, then we modify
   // both the listen port AND the options.url
-  if (process.env.JSBIN_PORT) {
+  if (process.env.JSBIN_PORT && !process.env.JSBIN_PROXY_HOST) {
     if (options.url.host.indexOf(':') === -1) {
       options.url.host += ':' + process.env.JSBIN_PORT;
     } else {
@@ -66,6 +66,8 @@ if (!process.env.TZ && options.timezone) {
         return ':' + process.env.JSBIN_PORT;
       });
     }
+  } else if(process.env.JSBIN_PROXY_HOST) {
+    port = process.env.JSBIN_PORT;
   }
 
   if (!port) {


### PR DESCRIPTION
When proxying a local jsbin instance via another server running on port 80 a CORS error arises when trying to do a `history.replaceState` with `jsbin.getURL()`. The problem is that `jsbin.root` has the port appended to it, but I want all requests to go through the configured host _without the port_.

This commit allows setting JSBIN_PROXY_HOST to keep the port from being appeded to the host. That way jsbin.root is just `jsbin.dev` not `jsbin.dev:PORT`, but the server still runs on the passed in port.

I didn't have time to dig into how to make this a setting in the config file. Is that pretty easy to add?
