### PR TITLE
Include the latest stable angularJS 1.2.1 from cloudflare.

### DIFF
--- a/public/js/editors/libraries.js
+++ b/public/js/editors/libraries.js
@@ -254,6 +254,11 @@ var libraries = [
     "group": "Zepto"
   },
   {
+    "url": "http://cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.1/angular.min.js",
+    "label": "Angular 1.2.1 Stable",
+    "group": "Angular"
+  },
+  {
     "url":"https://ajax.googleapis.com/ajax/libs/angularjs/1.1.5/angular.min.js",
     "label": "Angular 1.1.5 Unstable",
     "group": "Angular"


### PR DESCRIPTION
Include the latest stable angularJS 1.2.1 from cloudflare.
