### PR TITLE
Removing the override of createModels method

### DIFF
--- a/lib/models/index.js
+++ b/lib/models/index.js
@@ -25,11 +25,5 @@ module.exports.createModels = function (store) {
     }
   }
 
-  // Clear the method and return cached result
-  initialised.createModels = function() {
-    console.log('Models have already been initialised');
-    return initialised;
-  };
-
   return initialised;
 };


### PR DESCRIPTION
This now keeps in check with @aron 's ideas for clearing Model instances in tests
