### PR TITLE
Moving check for bin not existing in db out side of active check

### DIFF
--- a/lib/models/bin.js
+++ b/lib/models/bin.js
@@ -34,7 +34,7 @@ var model = {
     // This will only occur if it isn't a real bin, it has been created
     // on from default files and does not exist in any database. By this
     // logic the bin must be public, it has no owner and no record.
-    if (!bin.metadata) {
+    if (!bin || !bin.metadata) {
       return true;
     }
     // this should only let users see the latest


### PR DESCRIPTION
Active will not be set until bin is in database, if the bin has no metadata, it means it does not exist in teh database and has been created form default files.
This resolves #1036 
