### PR TITLE
Move Ember dependency loading into head.

### DIFF
--- a/public/custom/emberjs/default.html
+++ b/public/custom/emberjs/default.html
@@ -4,6 +4,9 @@
 <meta charset="utf-8">
 <title>Ember Starter Kit</title>
   <link rel="stylesheet" href="http://cdnjs.cloudflare.com/ajax/libs/normalize/2.1.0/normalize.css">
+  <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
+  <script src="http://builds.handlebarsjs.com.s3.amazonaws.com/handlebars-v1.2.1.js"></script>
+  <script src="http://builds.emberjs.com/tags/v1.3.1/ember.js"></script>
 </head>
 <body>
   
@@ -20,9 +23,5 @@
     {{/each}}
     </ul>
   </script>
-  
-  <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
-  <script src="http://builds.handlebarsjs.com.s3.amazonaws.com/handlebars-v1.2.1.js"></script>
-  <script src="http://builds.emberjs.com/tags/v1.3.1/ember.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Without this change the first run of any ember application fails everytime
(since `Ember` isn't defined).
