### PR TITLE
Update library.js

### DIFF
--- a/public/js/editors/library.js
+++ b/public/js/editors/library.js
@@ -37,7 +37,7 @@ $library.bind('init', function () {
 
   for (i = 0; i < groupOrder.length; i++) {
     group = groups[groupOrder[i]];
-    html.push('<optgroup value="' + group.label + '" data-group="' + group.label + '" class="heading"></optgroup>');
+    html.push('<optgroup value="" label="' + group.label + '" data-group="' + group.label + '" class="heading"></optgroup>');
 
     for (j = 0; j < group.libraries.length; j++) {
       library = group.libraries[j];


### PR DESCRIPTION
Change library headings to an empty optgroup.
![optgroupjsb](https://f.cloud.github.com/assets/442793/2032806/3474f386-8914-11e3-8fb7-d874a1ccf909.png)

Optgroup could also go around the options but that would add a margin on the left of each.
