### PR TITLE
Updated links to Bootstrap 3 CSS and JS.

### DIFF
--- a/public/js/editors/libraries.js
+++ b/public/js/editors/libraries.js
@@ -104,8 +104,8 @@ var libraries = [
   {
     'url': [
       'http://code.jquery.com/jquery.min.js',
-      'http://getbootstrap.com/dist/css/bootstrap.css',
-      'http://getbootstrap.com/dist/js/bootstrap.js'
+      'http://netdna.bootstrapcdn.com/bootstrap/latest/css/bootstrap.min.css',
+      'http://netdna.bootstrapcdn.com/bootstrap/latest/js/bootstrap.min.js'
     ],
     'label': 'Bootstrap Latest',
     'group': 'Bootstrap'


### PR DESCRIPTION
I've used latest instead of 3.1.0, hoping it keeps mostly current over time. Though right now, latest points to 3.0.3 when 3.1.0 is out and referenced by the getbootstrap.com website.
