### PR TITLE
Update to 1.3.2.

### DIFF
--- a/public/custom/emberjs/default.html
+++ b/public/custom/emberjs/default.html
@@ -6,7 +6,7 @@
   <link rel="stylesheet" href="http://cdnjs.cloudflare.com/ajax/libs/normalize/2.1.0/normalize.css">
   <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
   <script src="http://builds.handlebarsjs.com.s3.amazonaws.com/handlebars-v1.2.1.js"></script>
-  <script src="http://builds.emberjs.com/tags/v1.3.1/ember.js"></script>
+  <script src="http://builds.emberjs.com/tags/v1.3.2/ember.js"></script>
 </head>
 <body>
   


### PR DESCRIPTION
Fixes an XSS exploit in `{{link-to}}`.

https://groups.google.com/forum/#!topic/ember-security/1h6FRgr8lXQ.
