### PR TITLE
Make the config environment variable override mechanism support environment variables that contain true/on or false/off.

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -64,9 +64,9 @@ function importEnvVars(collection, envPrefix) {
         envValue = process.env[envKey];
     if ((typeof(value) == 'number') || (typeof(value) == 'string') || (typeof(value) == 'boolean') || (value == null)) {
       if (envValue && typeof(envValue == 'string')) {
-        if (envValue.match(/\s*(true|on)\s*/i)) {
+        if (envValue.match(/^\s*(true|on)\s*$/i)) {
           envValue = true;
-        } else if (envValue.match(/\s*(false|off)\s*/i)) {
+        } else if (envValue.match(/^\s*(false|off)\s*$/i)) {
           envValue = false;
         }
         collection[key] = envValue;


### PR DESCRIPTION
As of today all environment variables set for overriding the json config will be reset to `true` or `false` if the value of the environment variables contain the string `true`/`on` or `false`/`off` respectively.

That means e.g.

`JSBIN_STORE_SQLITE_LOCATION=a/long/path`

results in a variable

`JSBIN_STORE_SQLITE_LOCATION=true`

since `long` contains **on**

This fixes the attempt to support leading and trailing spaces for the truthy and falsy values.
