### PR TITLE
Stop duplicate copies of React from auto-adding

### DIFF
--- a/public/js/editors/libraries.js
+++ b/public/js/editors/libraries.js
@@ -272,7 +272,7 @@ var libraries = [
     'group': 'Angular'
   },
   {
-    'url': '//fb.me/react-0.8.0.min.js',
+    'url': '//fb.me/react-0.8.0.js',
     'label': 'React 0.8.0',
     'group': 'React'
   },
@@ -452,12 +452,6 @@ var libraries = [
       '//cdnjs.cloudflare.com/ajax/libs/polymer/0.1.1/polymer.js'
     ],
     'label': 'Polymer 0.1.1'
-  },
-  {
-    'url': [
-      '//fb.me/react-with-addons-0.8.0.js'
-    ],
-    'label': 'React 0.8.0'
   },
   {
     'url': '//netdna.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.min.css',

--- a/public/js/processors/processor.js
+++ b/public/js/processors/processor.js
@@ -146,7 +146,12 @@ var processors = jsbin.processors = (function () {
       extensions: ['jsx'],
       url: jsbin.static + '/js/vendor/JSXTransformer.js',
       init: function (ready) {
-        $('#library').val( $('#library').find(':contains("React")').val() ).trigger('change');
+        // Don't add React if the code already contains a script whose name
+        // starts with 'react', to avoid duplicate copies.
+        var code = editors.html.getCode();
+        if (!(/<script[^>]*src=\S*\breact\b/i).test(code)) {
+          $('#library').val( $('#library').find(':contains("React with Add-Ons")').val() ).trigger('change');
+        }
         ready();
       },
       handler: function (source) {


### PR DESCRIPTION
Previously, selecting "JSX (React)" could cause react-0.8.0.js to be added, even if the add-ons build or a different version was already included by hand. Now we won't add it if the HTML contains anything that looks like a React script tag.

Also changed it to use unminified builds for better warnings and to default to the add-ons build because it's more general.

Test Plan:
In a new bin, selected "JSX (React)" and saw that the add-ons script tag was added. In a separate bin, added a script tag for react-0.9.0-rc1.js, then selected JSX and the HTML didn't change.
