### PR TITLE
Fixed bin summary generation on bin rev update

### DIFF
--- a/lib/handlers/bin.js
+++ b/lib/handlers/bin.js
@@ -492,7 +492,7 @@ module.exports = Observable.extend({
       params.revision = req.param('revision');
       params.url = req.param('code');
       params.settings = req.param('settings');
-      params.summary = utils.titleForBin(params);
+      params.summary = utils.titleForBin(req.bin);
       params.panel = panel;
       params.panel_open = !!params[panel];
 


### PR DESCRIPTION
Until now, when updating a bin, the summary was re-generated based only on changed panel contents - I switched an argument for utils.titleForBin() call so now it know the whole bin contents and is able to return proper title.
In other words, it now works with logic compatible to utils.titleForBin() - preferring html panel, not the one that has just changed.
