### PR TITLE
Support custom SSL hosts, and fixed SSL feature

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,6 +1,9 @@
+'use strict';
 // A collection of useful methods that are essentially utils but are
 // specific to the application and require access to the app object.
 var config = require('./config');
+var undefsafe = require('undefsafe');
+
 module.exports.createHelpers = function createHelpers(app) {
   return {
     // Proxied access to the Application#set() method.
@@ -50,7 +53,8 @@ module.exports.createHelpers = function createHelpers(app) {
       }
 
       if (secure) {
-        root = root.replace(/http:/, 'https:');
+        root = undefsafe(config, 'url.ssl.host') || undefsafe(config, 'url.host');
+        root = 'https://' + root;
       }
 
       return path ? root  + '/' + path : root;
@@ -100,7 +104,7 @@ module.exports.createHelpers = function createHelpers(app) {
       }
 
       if (secure) {
-        root = config.url.static || config.url.host;
+        root = undefsafe(config, 'url.ssl.static') || undefsafe(config, 'url.static') || undefsafe(config, 'url.host');
         proto = 'https';
       }
 

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -4,6 +4,7 @@ var utils   = require('./utils'),
     connect = require('express/node_modules/connect'),
     models  = require('./models'),
     config  = require('./config'),
+    features = require('./features'),
     parse = require('url').parse;
 
 // Custom middleware used by the application.
@@ -254,6 +255,13 @@ module.exports = {
     };
   },
   protocolCheck: function(req, res, next) {
+    // this is a bit of a hack, because the protocolCheck should be supported
+    // no matter what, but since we're using feature flags, this gets very
+    // messy when it goes live without the feature flag test in place.
+    if (!features('sslLogin', req)) {
+      return next();
+    }
+
     if (!config.url.ssl) {
       if (req.secure) {
         return res.redirect('http://' + req.headers.host.replace(/:.*/, '') + req.url);


### PR DESCRIPTION
The issue was as soon as we turned on SSL, the non-SSL login would start failing. This is because the protocol check would kick in, and then block the login from working.

I've added a feature flag check (which I'm not mad on) which fixes this so that if the feature flag is enabled for the request, then the url redirect kicks in. If it's not enabled for the user, then the redirect is ignored entirely.

Related (and fixes #1234)
