### PR TITLE
Solarized + Vim style improvements

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -4367,6 +4367,12 @@ html * {
 .cm-s-solarized.cm-s-light {
   text-shadow: none;
 }
+.cm-s-solarized.cm-s-light .CodeMirror-selected {
+  background:none repeat scroll 0% 0% #002b36;
+}
+.cm-s-solarized.cm-s-dark .CodeMirror-selected {
+  background:none repeat scroll 0% 0% #fdf6e3;
+}
 
 
 @media only screen and (max-width: 700px) {


### PR DESCRIPTION
The fat cursor in vim should be the alternate background when using solarized, the text-shadow makes this look awful.
