### PR TITLE
Disable Dave img ghosting

### DIFF
--- a/public/css/static-page.css
+++ b/public/css/static-page.css
@@ -85,6 +85,9 @@ p em {
 #dave {
   float: left;
   margin-top: 3em
+  user-drag: none; 
+  -moz-user-select: none; 
+  -webkit-user-drag: none;
 }
 
 #welcome > h2 {


### PR DESCRIPTION
When playing with Dave (dragging), Chrome shows annoying ghost image. Tested on Chrome 34 for Mac (current stable). This is a fix for it.
