### PR TITLE
Fix login and edit links.

### DIFF
--- a/public/js/render/edit.js
+++ b/public/js/render/edit.js
@@ -6,7 +6,7 @@ function jsbinShowEdit(options) {
   var moveTimer, over,
   doc = document,
   aEL = 'addEventListener',
-  path = options.root + window.location.pathname,
+  path = window.location.href,
   style = doc.createElement('link'),
   btn = doc.createElement('a');
 

--- a/views/index.html
+++ b/views/index.html
@@ -168,7 +168,7 @@
               {{#feature request "sslLogin"}}
                 <div class="menu">
                   {{#feature request "github"}}
-                  <a href="/login" class="button button-dropdown focusbtn" id="loginbtn">Login or Register</a>
+                  <a href="{{root}}/login" class="button button-dropdown focusbtn" id="loginbtn">Login or Register</a>
                   <div class="dropdown login" id="registerLogin">
                     <div class="dropdowncontent">
                       <a class="btn-github" href="/auth/github">
@@ -177,12 +177,12 @@
                       </a>
                       <span class="login-group">
                         Or
-                        <a class="btn-login" href="/login">use your email address</a>
+                        <a class="btn-login" href="{{root}}/login">use your email address</a>
                       </span>
                     </div>
                   </div>
                   {{else}}
-                  <a href="/login" class="button" id="loginbtn">Login or Register</a>
+                  <a href="{{root}}/login" class="button" id="loginbtn">Login or Register</a>
                   {{/feature}}
                 </div>
               {{else}}


### PR DESCRIPTION
I set up a private installation of JSBin earlier today and noticed two issues:
1. The "login / register" link points at `/login`. This doesn't work when JSBin is running with a prefix.
2. The "Edit in JSBin" button on the output page didn't work properly. When running JSBin under `/jsbin` it would actually point at `/jsbin/jsbin/...`. 

These changes should fix both issues.
