### PR TITLE
Libraries: upgrade Polymer 0.1.1 to 0.2.3

### DIFF
--- a/public/js/editors/libraries.js
+++ b/public/js/editors/libraries.js
@@ -450,10 +450,10 @@ var libraries = [
   },
   {
     'url': [
-      '//cdnjs.cloudflare.com/ajax/libs/polymer/0.1.1/platform.js',
-      '//cdnjs.cloudflare.com/ajax/libs/polymer/0.1.1/polymer.js'
+      '//cdnjs.cloudflare.com/ajax/libs/polymer/0.2.3/platform.js',
+      '//cdnjs.cloudflare.com/ajax/libs/polymer/0.2.3/polymer.js'
     ],
-    'label': 'Polymer 0.1.1'
+    'label': 'Polymer 0.2.3'
   },
   {
     'url': '//netdna.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.min.css',


### PR DESCRIPTION
The current version of Polymer offered by JSBin is approximately [5 months old](https://github.com/cdnjs/cdnjs/tree/master/ajax/libs/polymer/0.1.1). This upgrades the CDNJS paths to point to the latest versions of Platform.js and Polymer.js (0.2.3).

:sunglasses: 
