### PR TITLE
Remove modulus from percentage calculation

### DIFF
--- a/lib/features.js
+++ b/lib/features.js
@@ -59,13 +59,8 @@ function ipAsNum(req) {
 }
 
 function percentage(n, req) {
-  var mod = parseInt(100 / n, 10); // ensures whole number
-  if (mod === 0) {
-    mod = 1;
-  }
   var ip = ipAsNum(req);
-
-  return ip % mod === 0;
+  return (ip / 256) <= (n / 100);
 }
 
 


### PR DESCRIPTION
Instead take the last part of ip, divide by 256 to get percentage and compare to percentage passed in.

//cc @remy 
