### PR TITLE
fixing gist for new github gist ids

### DIFF
--- a/public/js/chrome/app.js
+++ b/public/js/chrome/app.js
@@ -1,18 +1,9 @@
-// if a gist has been requested, lazy load the gist library and plug it in
-if (/gist(\/.*)?\/\d+/.test(window.location.pathname) && (!sessionStorage.getItem('javascript') && !sessionStorage.getItem('html'))) {
-  window.editors = editors; // needs to be global when the callback triggers to set the content
-  loadGist = function () {
-    $.getScript(jsbin.static + '/js/chrome/gist.js', function () {
-      window.gist = new Gist(window.location.pathname.replace(/.*\/([^/]+)$/, "$1"));
-    });
-  };
-
-  if (editors.ready) {
-    loadGist();
-  } else {
-    $document.on('jsbinReady', loadGist);
+$(function() {
+  // if a gist has been requested, lazy load the gist library and plug it in
+  if (/gist\/.*/.test(window.location.pathname) && (!sessionStorage.getItem('javascript') && !sessionStorage.getItem('html'))) {
+    window.gist = new Gist(window.location.pathname.replace(/.*\/([^/]+)$/, "$1"));
   }
-}
+});
 
 // prevent the app from accidently getting scrolled out of view
 if (!jsbin.mobile) document.body.onscroll = window.onscroll = function () {


### PR DESCRIPTION
It looks like github changed the way they build gist ids, previously they were numerical now they are not. This regex appears to work for both and should fix #1505
