### PR TITLE
Check for absence of res.connection

### DIFF
--- a/lib/spike/index.js
+++ b/lib/spike/index.js
@@ -35,7 +35,7 @@ replify('spike', {
 setInterval(function () {
   Object.keys(sessions).forEach(function (id) {
     sessions[id].res.forEach(function (res) {
-      if (!res.connection.writable) {
+      if (!res.connection || !res.connection.writable) {
         utils.removeConnection(id, res);
       }
     });


### PR DESCRIPTION
Previously we were checking if the connection was writable, and if not removing it from the spike, now we check if the connection even exists, and if not remove it from the spike, if it does exist we implement the same logic as before, checking if it's writable.

This fixes the issue that caused a restart at approx 12:35 today
