### PR TITLE
Use BootstrapCDN in libraries configuration. Closes #1564

### DIFF
--- a/public/js/editors/libraries.js
+++ b/public/js/editors/libraries.js
@@ -99,8 +99,8 @@ var libraries = [
   {
     'url': [
       'http://code.jquery.com/jquery.min.js',
-      'http://getbootstrap.com/dist/css/bootstrap.css',
-      'http://getbootstrap.com/dist/js/bootstrap.js'
+      'http://maxcdn.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css',
+      'http://maxcdn.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js'
     ],
     'label': 'Bootstrap Latest',
     'group': 'Bootstrap'
@@ -108,9 +108,8 @@ var libraries = [
   {
     'url': [
       'http://code.jquery.com/jquery.min.js',
-      'http://getbootstrap.com/2.3.2/assets/css/bootstrap.css',
-      'http://getbootstrap.com/2.3.2/assets/css/bootstrap-responsive.css',
-      'http://getbootstrap.com/2.3.2/assets/js/bootstrap.js'
+      'http://netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/css/bootstrap-combined.min.css',
+      'http://netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/js/bootstrap.min.js'
     ],
     'label': 'Bootstrap 2.3.2',
     'group': 'Bootstrap'


### PR DESCRIPTION
This PR introduces CDN version of Bootstrap both for current Bootstrap 3 version (3.1.1 as of time of writing) and latest version of Bootstrap 2 version (2.3.2) to be used in JSBin editor "Add library" feature.

The 2.3.2 version uses slightly different assets when enabling Bootstrap 2 responsive features - it uses combined stylesheet file instead of two separate files as per Bootstrap 2 docs - but that is how [bootstrapcdn.com](http://www.bootstrapcdn.com/) hosts Bootstrap versions I think.

Tested locally
