### PR TITLE
Ensure POST'ed content takes precedent over user template

### DIFF
--- a/lib/handlers/bin.js
+++ b/lib/handlers/bin.js
@@ -76,6 +76,8 @@ module.exports = Observable.extend({
       data.settings.processors = processorSettings;
     }
 
+    data.post = true;
+
     this.render(req, res, data);
   },
   getCustom: function (req, res, next) {
@@ -1063,6 +1065,10 @@ module.exports = Observable.extend({
     'html css javascript'.split(' ').forEach(function (panel) {
       template[panel] = utils.cleanForRender(template[panel] || '');
     });
+
+    if (bin.post) {
+      template.post = bin.post;
+    }
 
     template.url = this.helpers.jsbinURL(bin); //.permalink;
     return template;

--- a/public/js/editors/panel.js
+++ b/public/js/editors/panel.js
@@ -119,7 +119,7 @@ var Panel = function (name, settings) {
     // Bind events using CM3 syntax
     panel.editor.on('change', function codeChange(cm, changeObj) {
       if (jsbin.saveDisabled) {
-        $document.trigger('codeChange.live', [{ panelId: panel.id, revert: true, origin: changeObj.origin }]);  
+        $document.trigger('codeChange.live', [{ panelId: panel.id, revert: true, origin: changeObj.origin }]);
       } else {
         $document.trigger('codeChange', [{ panelId: panel.id, revert: true, origin: changeObj.origin }]);
       }
@@ -532,7 +532,7 @@ function populateEditor(editor, panel) {
       // tell the document that it's currently being edited, but check that it doesn't match the saved template
       // because sessionStorage gets set on a reload
       changed = cached != saved && cached != template[panel];
-    } else if (saved !== null && !/edit/.test(window.location) && !window.location.search) { // then their saved preference
+    } else if (!template.post && saved !== null && !/edit/.test(window.location) && !window.location.search) { // then their saved preference
       editor.setCode(saved);
     } else { // otherwise fall back on the JS Bin default
       editor.setCode(template[panel]);


### PR DESCRIPTION
Set a flag saying the content came from a POST, and then prefer the posted content over the user defined template.

Fixed #1565.
