### PR TITLE
#1571 setting indentUnit and fixing problems of it with Tern

### DIFF
--- a/public/js/account/editor-settings.js
+++ b/public/js/account/editor-settings.js
@@ -138,6 +138,7 @@
     editor.setOption('lineNumbers', $lineNumbers.prop('checked'));
     editor.setOption('indentWithTabs', $indentWithTabs.prop('checked'));
     editor.setOption('tabSize', $tabSize.val());
+    editor.setOption('indentUnit', $tabSize.val());
     editor.setOption('theme', $theme.val());
     $CodeMirror.css('font-size', $fontsize.val()+'px');
     editor.refresh();

--- a/public/js/editors/tern.js
+++ b/public/js/editors/tern.js
@@ -2,6 +2,9 @@
   'use strict';
 
   /*globals $, jsbin, CodeMirror, template, ternDefinitions, ternBasicDefs */
+  if (!jsbin.settings.addons.tern) {
+    return;
+  }
 
   var ternServer;
   var ternLoaded = {};
@@ -90,7 +93,7 @@
       if (cm.options.indentWithTabs) {
         indent = '\t';
       } else {
-        indent = new Array(cm.options.indentUnit + 1).join(' ');
+        indent = new Array(cm.options.indentUnit * 1 + 1).join(' ');
       }
 
       if (tok.string === ';') {


### PR DESCRIPTION
Fix for #1571 
CodeMirror has two different settings for the indentation, we need to set both to the value wanted.
Also, this would cause some problems with Tern autocomplete (at least in development stage), so I create the Tern autocomplete function only if its settings are true, not just if the script is loaded (as it was before).
Note: we indentation is not completely correct in the preview editor (I think because we don't load all the addons and scripts and settings)
