### PR TITLE
Use Modernizr development version. Closes #520

### DIFF
--- a/public/js/editors/libraries.js
+++ b/public/js/editors/libraries.js
@@ -384,8 +384,8 @@ var libraries = [
     'label': 'Lo-Dash 2.4.1'
   },
   {
-    'url': 'http://cdnjs.cloudflare.com/ajax/libs/modernizr/2.6.2/modernizr.min.js',
-    'label': 'Modernizr 2.6.2'
+    'url': 'http://modernizr.com/downloads/modernizr-latest.js',
+    'label': 'Modernizr Development latest'
   },
   {
     'url': 'http://cdnjs.cloudflare.com/ajax/libs/prefixfree/1.0.7/prefixfree.min.js',


### PR DESCRIPTION
Quoting from [modernizr.com](http://modernizr.com):

> Use the Development version to develop with and learn from. Then, when you’re ready for production, use the build tool below to pick only the tests you need.

This PR replaces Modernizr library from a custom, minified version from CDN to the latest development version hosted on project's own website.
