### PR TITLE
Add a "clear" button to the console

### DIFF
--- a/public/js/chrome/navigation.js
+++ b/public/js/chrome/navigation.js
@@ -221,6 +221,11 @@ $('#runconsole').click(function () {
   return false;
 });
 
+$('#clearconsole').click(function () {  
+  jsconsole.clear();
+  return false;
+});
+
 $('#showhelp').click(function () {
   $body.toggleClass('keyboardHelp');
   keyboardHelpVisible = $body.is('.keyboardHelp');

--- a/views/index.html
+++ b/views/index.html
@@ -345,6 +345,7 @@
         <span class="name"><strong>Console</strong></span>
         <span class="options">
           <button id="runconsole" title="ctrl + enter">Run</button>
+          <button id="clearconsole" title="ctrl + l">Clear</button>
         </span>
       </div>
       <div id="console" class="stretch"><ul id="output"></ul><form>


### PR DESCRIPTION
I made a few changes but I kept each one in a separate commit to make it easier to see what each one does.
1. code cleanup, change hidebutton to togglebutton  https://github.com/tekay/jsbin/commit/54224283f5ca6e4cdeaa9e7e9dd5a8537bdb2d23
2. add a "clear" button to the console (currently the only way to clear it via the UI is to close and repopen the console) https://github.com/tekay/jsbin/commit/a43b51df84fec4451e1d9143a0ebd16c2c3e2c12
3. fixed the keyboard shortcut to clear the console in chrome on a mac (cmd+l just sets focus to the address bar) https://github.com/tekay/jsbin/commit/a4593fe3990d3bb60b5192d86f86f391e36d8dd8
4. update the console "clear" buttons title to "cmd+k" if on a mac
