### PR TITLE
Update Bootstrap to version 3.2. Closes #1604

### DIFF
--- a/public/js/editors/libraries.js
+++ b/public/js/editors/libraries.js
@@ -99,8 +99,8 @@ var libraries = [
   {
     'url': [
       'http://code.jquery.com/jquery.min.js',
-      'http://maxcdn.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css',
-      'http://maxcdn.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js'
+      'http://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css',
+      'http://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js'
     ],
     'label': 'Bootstrap Latest',
     'group': 'Bootstrap'


### PR DESCRIPTION
New version of Bootstrap has been released. For details please see:

[http://blog.getbootstrap.com/2014/06/26/bootstrap-3-2-0-released/](http://blog.getbootstrap.com/2014/06/26/bootstrap-3-2-0-released/)

This commit updates version
used by JSBin libraries.
After the update if Bootstrap latest menu option is used following scripts will be inserted into page content:

``` html
<script src="http://code.jquery.com/jquery.min.js"></script>
<link href="http://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css" rel="stylesheet" type="text/css" />
<script src="http://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js"></script>
```

tested locally with current master
