### PR TITLE
Add Bluebird library to work with promises.

### DIFF
--- a/public/js/editors/libraries.js
+++ b/public/js/editors/libraries.js
@@ -315,6 +315,26 @@ var libraries = [
     'group': 'Enyo'
   },
   {
+    'url': '//cdnjs.cloudflare.com/ajax/libs/bluebird/1.2.2/bluebird.js',
+    'label': 'Bluebird 1.2.2',
+    'group': 'Promises'
+  },
+  {
+    'url': 'https://www.promisejs.org/polyfills/promise-4.0.0.js',
+    'label': 'Promise 4.0.0',
+    'group': 'Promises'
+  },
+  {
+    'url': '//cdnjs.cloudflare.com/ajax/libs/q.js/1.0.1/q.js',
+    'label': 'Q 1.0.1',
+    'group': 'Promises'
+  },
+  {
+    'url': '//cdn.jsdelivr.net/rsvp/3.0.6/rsvp.js',
+    'label': 'RSVP 3.0.6',
+    'group': 'Promises'
+  },
+  {
     'url': [
       'https://rawgithub.com/ai/autoprefixer-rails/master/vendor/autoprefixer.js'
     ],
@@ -339,10 +359,6 @@ var libraries = [
   {
     'url': 'http://cdnjs.cloudflare.com/ajax/libs/bonsai/0.4/bonsai.min.js',
     'label': 'Bonsai 0.4.latest'
-  },
-  {
-    'url': '//cdnjs.cloudflare.com/ajax/libs/bluebird/1.2.2/bluebird.js',
-    'label': 'Bluebird 1.2.2'
   },
   {
     'url': 'http://jashkenas.github.io/coffee-script/extras/coffee-script.js',


### PR DESCRIPTION
Small commit to add  [bluebird](https://github.com/petkaantonov/bluebird) to the list of available libraries, as referred on [twitter](https://twitter.com/js_bin/status/483615751140831232).

So, I reckon that Dave preferes the [promise.js](https://github.com/then/promise) library, I didn't know it until Dave talked about it, so please correct me if that's not the right library,

However, I still rather to add bluebird instead of promise, since bluebird focus on features and performance, which makes it useful even after all browsers have implemented native Promises, but this is just my two cents.

If you still rather have the promises library instead, I don't mind to fix this commit :)
