### PR TITLE
Search for meta charset tag and put comment after

### DIFF
--- a/lib/handlers/bin.js
+++ b/lib/handlers/bin.js
@@ -1263,9 +1263,19 @@ module.exports = Observable.extend({
 
       // Append attribution comment to header.
       helpers.render('comment', context, function (err, comment) {
-        formatted = formatted.replace(/<html[^>]*>/, function ($0) {
+        var done = false;
+        formatted = formatted.replace(/<meta.*?charset.*?[^>]*>/, function ($0) {
+          if ($0) {
+            done = true;
+          }
           return $0 + '\n' + (comment || '').trim();
         });
+
+        if (!done) {
+          formatted = formatted.replace(/<html[^>]*>/, function ($0) {
+            return $0 + '\n' + (comment || '').trim();
+          });
+        }
         return fn(err || null, err ? undefined : formatted);
       });
     }


### PR DESCRIPTION
First test for the meta tag with a charset property, and insert the license copy below.

If that's not found, put it after the html element. Sure, we should probably look for the title tag, but let's face it, it's just a dumping ground for test code, and dear author: include a meta charset for heavens' sake.

...okay, maybe I should do the title check too, but maybe _after_ someone files an issue.
