### PR TITLE
Fixed #1174

### DIFF
--- a/lib/handlers/bin.js
+++ b/lib/handlers/bin.js
@@ -556,7 +556,7 @@ module.exports = Observable.extend({
             // Notify interested parties (spike) that a new revision was created
             var oldBin = req.bin;
             handler.once('created', function (newBin) {
-              handler.emit('new-revision', oldBin, newBin);
+              handler.emit('new-revision', bin, newBin);
             });
 
             handler.completeCreateBin(result, req, res, next);


### PR DESCRIPTION
Ensure the _old_ bin is going in to do the bump lookup. Somehow it was using the latest bin (suspect the line that changes the req.bin, via spike/index.js)
