### PR TITLE
x-frame-options applied to full bin output

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -91,6 +91,11 @@ module.exports = function (app) {
     next();
   }
 
+  function noframes(req, res, next) {
+    res.setHeader('X-Frame-Options', 'DENY');
+    next();
+  }
+
   // Redirects
 
   // /about doesn't get hit in production - it goes via nginx to our learn repo
@@ -160,13 +165,21 @@ module.exports = function (app) {
   app.get(/(?:.*\/(edit|watch|download|source)|^\/$)$/, function (req, res, next) {
     var ssl = features('sslForAll', req);
 
-
     if ( (!req.secure && ssl) || // a) request *should* be secure
          (req.secure && !ssl) ) { // b) request is secure and *should not* be
       var url = sandbox.helpers.url(req.url, true, ssl);
       return res.redirect(url);
     }
 
+    next('route');
+  });
+
+  // secure the following paths from being iframed, note that it's also applied
+  // to full bin output
+  app.get('/auth/*', noframes, function (req, res, next) {
+    next('route');
+  });
+  app.get('/account/*', noframes, function (req, res, next) {
     next('route');
   });
 
@@ -519,6 +532,9 @@ module.exports = function (app) {
     var settings = {};
     var ssl = false;
     var url;
+
+    // apply x-frame-options, but pass a dummy `next`
+    noframes(req, res, function () {});
 
     if (settings) {
       try {


### PR DESCRIPTION
Applies x-frame-options to the full output of bins - obviously this excludes the [embedded view](http://jsbin.com/help/how-can-i-embed-jsbin).
