### PR TITLE
Added support for sans-serif fonts on Windows

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -4454,7 +4454,7 @@ html * {
   bottom: 12px;
   right: 12px;
   float: left;
-  font-family: 'helvetica neue';
+  font-family: "Helvetica Neue", Helvetica, Arial;
   font-weight: 400;
   background: #fafafa;
   background: -moz-linear-gradient(top,  #FFF 0%, #FBFBFB 100%); /* FF3.6+ */


### PR DESCRIPTION
On my work computer, the contents of the .card element is displayed in Times New Roman as I don't have Helvetica Neue installed. I've added Helvetica and Arial to the selector to reflect how JS Bin handles fonts in other areas.
