### PR TITLE
OpenUI5 lib version is always latest

### DIFF
--- a/public/js/editors/libraries.js
+++ b/public/js/editors/libraries.js
@@ -519,7 +519,7 @@ var libraries = [
       'data-sap-ui-theme': 'sap_bluecrystal',
       'data-sap-ui-libs': 'sap.m'
     },
-    'label': 'OpenUI5 1.18.8 Mobile BlueCrystal'
+    'label': 'OpenUI5 latest (Mobile BlueCrystal)'
   },
   {
     'url': '//cdnjs.cloudflare.com/ajax/libs/gsap/1.11.7/TweenMax.min.js',


### PR DESCRIPTION
The OpenUI5 library available is always the latest, so the static description "1.18.8" was incorrect. Changed to "latest" (with lowercase L) in line with other library version descriptions. Now looks like this (below). Thanks.

![screen shot 2014-07-23 at 14 06 37](https://cloud.githubusercontent.com/assets/73068/3680275/512b854e-12ad-11e4-96a8-0f117a7e0d15.png)
