### PR TITLE
Fixing subdomain handling for Host request headers completely different

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -166,7 +166,7 @@ module.exports = {
         offset = host.indexOf(outputHost);
       }
 
-      if (offset) {
+      if (offset > 0) {
         // Slice the host from the subdomain and subtract 1 for
         // trailing . on the subdomain.
         req.subdomain = host.slice(0, offset - 1);


### PR DESCRIPTION
from the configured host (like behind an Apache reverse proxy)

host.indexOf(apphost) returns -1 in this case, which is a true value.
