### PR TITLE
Added Video.js to the libraries list

### DIFF
--- a/public/js/editors/libraries.js
+++ b/public/js/editors/libraries.js
@@ -528,6 +528,13 @@ var libraries = [
   {
     'url': '//cdnjs.cloudflare.com/ajax/libs/phaser/2.0.5/phaser.min.js',
     'label': 'Phaser 2.0.5'
+  },
+  {
+    'url': [
+      '//vjs.zencdn.net/4.6/video-js.css',
+      '//vjs.zencdn.net/4.6/video.js'
+    ],
+    'label': 'Video.js 4.6.x'
   }
 ];
 


### PR DESCRIPTION
Updated/squashed version of #623 with comment about removing `http:` resolved.
