### PR TITLE
Method to detect previously crashed state.

### DIFF
--- a/public/js/chrome/navigation.js
+++ b/public/js/chrome/navigation.js
@@ -332,6 +332,14 @@ $('#lostpass').click(function (e) {
 
 jsbin.settings.includejs = jsbin.settings.includejs === undefined ? true : jsbin.settings.includejs;
 
+if (sessionStorage.runnerPending) {
+  $document.trigger('tip', {
+    content: 'It looks like your last session may have crashed, so I\'ve disabled "Auto-run JS" for you',
+    type: 'notification'
+  });
+  jsbin.settings.includejs = false;
+}
+
 $('#enablejs').change(function () {
   jsbin.settings.includejs = this.checked;
   analytics.enableLiveJS(jsbin.settings.includejs);

--- a/public/js/render/live.js
+++ b/public/js/render/live.js
@@ -175,6 +175,16 @@ var renderer = (function () {
   };
 
   /**
+   * When the renderer is complete, it means we didn't hit an initial
+   * infinite loop
+   */
+  renderer.complete = function () {
+    try {
+      delete sessionStorage.runnerPending;
+    } catch (e) {}
+  };
+
+  /**
    * When the iframe resizes, update the size text
    */
   renderer.resize = (function () {
@@ -309,6 +319,11 @@ var renderLivePreview = (function () {
       if (!outputPanelOpen && !consolePanelOpen) {
         return;
       }
+      // this is a flag that helps detect crashed runners
+      if (jsbin.settings.includejs) {
+        sessionStorage.runnerPending = 1;
+      }
+
       renderer.postMessage('render', {
         source: source,
         options: {
@@ -324,6 +339,13 @@ var renderLivePreview = (function () {
   /**
    * Events
    */
+
+  $document.on('codeChange.live', function (event, arg) {
+    if (arg.origin === 'setValue' || arg.origin === undefined) {
+      return;
+    }
+    delete sessionStorage.runnerPending;
+  });
 
   // Listen for console input and post it to the iframe
   $document.on('console:run', function (event, cmd) {

--- a/public/js/runner/runner.js
+++ b/public/js/runner/runner.js
@@ -113,6 +113,8 @@ var runner = (function () {
       // Close the document. This will fire another DOMContentLoaded.
       childDoc.close();
 
+      runner.postMessage('complete');
+
       // Setup the new window
       sandbox.wrap(childWindow, data.options);
     });


### PR DESCRIPTION
When the browser renders the output with live JS enabled, it sets a flag, at's then removed (directly after we finish writing the contents of the iframe). _Or_ the can be removed by the user changing their code.

If the page is loaded, and the flag is present, that means the page somehow crashed during load time, so we automatically turn off live-js for the user and show them a message that we've done so.
