### PR TITLE
View source of single panel should call only its own preprocessor.

### DIFF
--- a/lib/handlers/bin.js
+++ b/lib/handlers/bin.js
@@ -304,7 +304,12 @@ module.exports = Observable.extend({
           } else if (settings.processors[format]) {
             // else we need to convert and process the source
             if (processors.support(settings.processors[format])) {
-              _this.applyProcessors(bin, format).then(function (results) {
+              // keep only the single processor we need
+              var singleProcessor = {};
+              singleProcessor[format] = settings.processors[format];
+              bin.settings.processors = singleProcessor;
+
+              _this.applyProcessors(bin).then(function (results) {
                 bin = results[0];
 
                 // Processor object
@@ -1209,9 +1214,7 @@ module.exports = Observable.extend({
   // applies the processors to the bin and generates the html, js, etc
   // based on the appropriate processor. Used in the previews and the API
   // requests.
-  // singleProcessor parameter is for calling only the selected preprocessor in
-  // getBinSourceFile when we request the generated source output of a single panel
-  applyProcessors: function (bin, singleProcessor) {
+  applyProcessors: function (bin) {
     var binSettings = {};
 
     // self defence against muppertary
@@ -1223,17 +1226,8 @@ module.exports = Observable.extend({
       binSettings = bin.settings;
     }
 
-    var listProcessors = {};
-    // if we want to preprocess only the requested panel
-    if (singleProcessor) {
-      listProcessors[singleProcessor] = binSettings.processors[singleProcessor];
-    } else {
-    // if we want to preprocess all panels
-      listProcessors = binSettings.processors;
-    }
-
     if (binSettings && binSettings.processors && Object.keys(binSettings.processors).length) {
-      return new RSVP.all(Object.keys(listProcessors).map(function (panel) {
+      return new RSVP.all(Object.keys(binSettings.processors).map(function (panel) {
         var processorName = binSettings.processors[panel],
             code = bin[panel];
         if (processors.support(processorName)) {


### PR DESCRIPTION
At the moment when we call something like bin.x.css and its content is of a preprocessed language, it will call all preprocessors connected to that bin.
With this fix it will call only the single selected processor.
