### PR TITLE
#1700 Trigger `size editor` after transition has completed

### DIFF
--- a/public/js/chrome/welcome-panel.js
+++ b/public/js/chrome/welcome-panel.js
@@ -44,6 +44,10 @@
     }
   };
 
+  $('.toppanel-logo').on('webkitTransitionEnd otransitionend oTransitionEnd msTransitionEnd transitionend', function(e) {
+    $document.trigger('sizeeditors');
+  });
+
   $('.toppanel-hide').click(function(event) {
     event.preventDefault();
     goSlow(event);


### PR DESCRIPTION
As per #1700 
Code from http://blog.teamtreehouse.com/using-jquery-to-detect-when-css3-animations-and-transitions-end
