### PR TITLE
Remove ctrl key from working for jsbin actions on Mac

### DIFF
--- a/public/js/editors/keycontrol.js
+++ b/public/js/editors/keycontrol.js
@@ -45,7 +45,7 @@ if (!customKeys.disabled) {
     var includeAltKey = customKeys.useAlt ? event.altKey : !event.altKey,
         closekey = customKeys.closePanel ? customKeys.closePanel : 48;
 
-    if (event.ctrlKey) { event.metaKey = true; }
+    if (event.ctrlKey && $.browser.platform !== 'mac') { event.metaKey = true; }
 
     if (event.metaKey && event.which === 89) {
       archive(!event.shiftKey);


### PR DESCRIPTION
For actions like save, archive, open, etc, both cmd and ctrl were working on Mac.
Remove the ctrl for Mac as it was overriding some other shortcuts.
