### PR TITLE
Add <base> to rendered frame.

### DIFF
--- a/public/js/runner/processor.js
+++ b/public/js/runner/processor.js
@@ -74,6 +74,11 @@ var processor = (function () {
     source = doctypeObj.tail;
     combinedSource.push(doctype);
 
+    // this ensures that requests are bounced away from
+    // jsbin when they're relative. They shouldn't be
+    // hitting jsbin directly for broken images, etc.
+    combinedSource.push('<base href="//null.jsbin.com/">');
+
     // Kill the blocking functions
     // IE requires that this is done in the script, rather than off the window
     // object outside of the doc.write.


### PR DESCRIPTION
This is an important change, because we're seeing /a lot/ of bins being created that contain a lot of images, and when they're using relative urls (or just placeholder text like "xxx") the images request jsbin.com, _with each keystroke_.

The knock on effect is that XHR requests to jsbin (for joining jsbins together) will fail if they're using relative urls.

I'd like to get feedback on the impact of this change, because it'll alleviate a lot of unnecessary pressure from our servers.

More details here: http://jsbin.com/help/linking-bins
