### PR TITLE
Allow reported bins to have their source viewed

### DIFF
--- a/lib/handlers/bin.js
+++ b/lib/handlers/bin.js
@@ -245,14 +245,12 @@ module.exports = Observable.extend({
   },
   // TODO decide whether this is used anymore
   getBinSource: function (req, res) {
-    this.protectVisibility(req.session.user, req.bin, function(err, bin){
-      res.contentType('json');
-      var output = JSON.stringify(this.templateFromBin(bin));
-      if (!req.ajax) {
-        res.contentType('js');
-        output = 'var template = ' + output;
-      }
-      res.send(output);
+    var copy = _.extend({}, req.bin);
+    copy.sourceOnly = req.sourceOnly;
+    this.protectVisibility(req.session.user, copy, function(err, bin){
+      res.contentType('text/plain');
+      var file = binToFile(bin, { proto: req.secure ? 'https' : 'http' });
+      res.send(file);
     }.bind(this));
   },
   getBinSourceFile: function (req, res) {
@@ -530,7 +528,7 @@ module.exports = Observable.extend({
               return next(err);
             }
 
-            that.models.bin.load(query, function (err, result) {
+            that.models.bin.load(req, query, function (err, result) {
               if (err) {
                 return next(err);
               }
@@ -836,9 +834,9 @@ module.exports = Observable.extend({
 
     // TODO: Re-factor this logic.
     if (rev === 'latest' || req.path.indexOf('save') !== -1) {
-      models.bin.latest(query, complete);
+      models.bin.latest(req, query, complete);
     } else {
-      models.bin.load(query, complete);
+      models.bin.load(req, query, complete);
     }
   },
   protectVisibility: function (user, bin, cb) {

--- a/lib/handlers/error.js
+++ b/lib/handlers/error.js
@@ -2,6 +2,7 @@
 var utils = require('../utils'),
     errors = require('../errors'),
     BinHandler = require('./bin'),
+    parse = require('url').parse,
     Observable = utils.Observable,
     crypto = require('crypto');
 
@@ -82,6 +83,8 @@ module.exports = Observable.extend({
 
     var views = ['error', 504, 502, 410, 423];
 
+    var url = parse(req.url);
+
     res.status(status).render(views.indexOf(view) !== -1 ? view : 'error', {
       version: req.app.locals.version,
       is_500: status !== 404, // Saves us having many error pages at the mo.
@@ -91,7 +94,7 @@ module.exports = Observable.extend({
       err: err,
       stack: err.stack ? err.stack : '',
       request: {
-        url: req.url,
+        url: url.pathname,
         method: req.method
       }
     });

--- a/lib/models/bin.js
+++ b/lib/models/bin.js
@@ -7,6 +7,7 @@ var Observable = require('../utils').Observable,
     dropbox = require('../dropbox'),
     processors = require('../processors'),
     blacklist = require('../blacklist'),
+    undefsafe = require('undefsafe'),
     createFileFromBin = require('bin-to-file');
 
 var binPanels = ['html', 'css', 'javascript'];
@@ -16,8 +17,8 @@ var model = {
     Observable.call(this);
     this.store = store;
   },
-  load: function (params, fn) {
-    this.store.getBin(params, this.binLoadCallback(params, fn));
+  load: function (req, params, fn) {
+    this.store.getBin(params, this.binLoadCallback(req, params, fn));
   },
   isVisible: function (bin, username) {
     if (!username) {
@@ -45,28 +46,38 @@ var model = {
       }
     }
 
+    console.log(bin);
+
+    if (bin.active === 'n' && bin.reported && bin.sourceOnly) {
+      return true;
+    }
+
     return false;
   },
-  latest: function (params, fn) {
-    this.store.getLatestBin(params, this.binLoadCallback(params, fn));
+  latest: function (req, params, fn) {
+    this.store.getLatestBin(params, this.binLoadCallback(req, params, fn));
   },
-  binLoadCallback: function (params, fn) {
-
+  binLoadCallback: function (req, params, fn) {
     return function (err, bin) {
       if (err || !bin) {
         return fn(err, null);
       }
 
-      if (blacklist.validate(bin) === false) {
+      // TODO check if user is validated
+      if (!undefsafe(req, 'session.user.validated') && blacklist.validate(bin) === false) {
         return fn(410);
       }
 
-      if (bin.active === 'n' && bin.reported) {
+      if (!req.sourceOnly && bin.active === 'n' && bin.reported) {
         return fn(423);
       }
 
       this.getBinMetadata(bin, function loadedGetMetadata(err, metadata) {
         bin.metadata = metadata;
+
+        if (req.sourceOnly) {
+          bin.sourceOnly = req.sourceOnly;
+        }
 
         if (typeof bin.metadata.settings === 'string') {
           try {

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -184,6 +184,10 @@ module.exports = function (app) {
       metrics.timing('request', now - req.start);
     });
 
+    if (req.route.path.slice(-('/source').length) === '/source') {
+      req.sourceOnly = true;
+    }
+
     next();
   }, userHandler.updateLastSeen, binHandler.loadBin, function (req, res, next) {
     if (req.bin) {
@@ -602,7 +606,8 @@ module.exports = function (app) {
    * Full output routes
    */
   // Source
-  app.get('/:bin/:rev?/source', secureOutput, time('request.source'), binHandler.getBinSource);
+  app.get('/:bin/:rev?/source', time('request.source'), binHandler.getBinSource);
+
   app.get('/:bin/:rev?.:format(' + Object.keys(processors.mime).join('|') + ')', secureOutput, time('request.source'), binHandler.getBinSourceFile);
   app.get('/:bin/:rev?/:format(js)', secureOutput, function (req, res) {
     // Redirect legacy /js suffix to the new .js extension.

--- a/views/423.html
+++ b/views/423.html
@@ -11,6 +11,7 @@
       <h1>This bin has been reported</h1>
       <p>This bin has been reported as suspicious in content, and has been forbidden from being part of the web.</p>
       <p>If you believe this to be a mistake, please raise an <a href="http://github.com/jsbin/reports/issues/new?title={{#encodeURIComponent}}Incorrectly reported bin{{/encodeURIComponent}}&body={{#encodeURIComponent}}Bin url: {{root}}{{request.url}}{{/encodeURIComponent}}">issue</a> and add any additional information you can to help diagnose this atrocity.</p>
+      <p><a href="{{root}}{{request.url}}/source">View the original source of this bin</a></p>
     </div>
   </body>
 </html>


### PR DESCRIPTION
Easier to assess reported bins. Adding /source circumvents reported bins.
