### PR TITLE
Updating jQuery libraries

### DIFF
--- a/public/js/editors/libraries.js
+++ b/public/js/editors/libraries.js
@@ -5,8 +5,8 @@ var libraries = [
     'group': 'jQuery'
   },
   {
-    'url': '//code.jquery.com/jquery-2.1.0.min.js',
-    'label': 'jQuery 2.1.0',
+    'url': '//code.jquery.com/jquery-2.1.1.min.js',
+    'label': 'jQuery 2.1.1',
     'group': 'jQuery'
   },
   {


### PR DESCRIPTION
According to release [blog post](http://blog.jquery.com/2014/05/01/jquery-1-11-1-and-2-1-1-released/): These are minor patch releases and shouldn’t pose any major compatibility issues.
