### PR TITLE
Fix header issue with svg being used inside objects

### DIFF
--- a/lib/handlers/bin.js
+++ b/lib/handlers/bin.js
@@ -283,6 +283,7 @@ module.exports = Observable.extend({
       if (format === 'svg') {
         contentType = 'image/svg+xml';
         req.bin.svg = req.bin.html;
+        res.set('X-Frame-Options', 'SAMEORIGIN');
       }
 
       var _this = this;


### PR DESCRIPTION
object is a psuedo iframe and so require we send the X-Frame-Options header not as DENY
