### PR TITLE
Don't try to render the console when hidden

### DIFF
--- a/public/js/render/live.js
+++ b/public/js/render/live.js
@@ -262,6 +262,10 @@ var renderer = (function () {
 
     if (!window._console) {return;}
     if (!window._console[method]) {method = 'log';}
+
+    // skip the entire console rendering if the console is hidden
+    if (!jsbin.panels.panels.console.visible) { return; }
+
     window._console[method].apply(window._console, args);
   };
 


### PR DESCRIPTION
Fixes #1851 - due to large object being "prettyPrinted" during the animation.
