### PR TITLE
Fixed alignment position of help drop down for IE

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -5521,7 +5521,6 @@ a[data-pro]:hover:after {
   outline: 0;
   width: 100%;
   box-sizing: border-box;
-  padding: 6px;
   font-size: 14px;
   margin: 0;
   padding: 6px 100px 6px 10px;
@@ -5542,6 +5541,14 @@ a[data-pro]:hover:after {
   text-align: right;
   width: 60px;
   display: inline-block;
+}
+
+#help.dd-right {
+  right: 0;
+}
+
+#results {
+  display: block;
 }
 
 #results a {


### PR DESCRIPTION
Before: right white margin that moves the entire layout
![before](https://cloud.githubusercontent.com/assets/458523/3979888/5f0e492c-285a-11e4-94f0-77cbcf8bfa8f.png)

After:
![after](https://cloud.githubusercontent.com/assets/458523/3979890/659fc180-285a-11e4-82d2-f8fcf7f97e7f.png)
