### PR TITLE
Check for existence of req.accepted[0]

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -133,7 +133,7 @@ module.exports = {
     return collected;
   },
   isAjax: function (req) {
-    return (req.get('X-Requested-With') || '').toLowerCase() === 'xmlhttprequest' || req.accepted[0].value === 'application/json';
+    return (req.get('X-Requested-With') || '').toLowerCase() === 'xmlhttprequest' || (req.accepted[0] && req.accepted[0].value === 'application/json');
   },
   shortcode: function (length) {
     var vowels = 'aeiou',


### PR DESCRIPTION
This stops us getting the cannot read property value of undefined TypeError
