### PR TITLE
Fixed #1904

### DIFF
--- a/public/js/editors/mobileCodeMirror.js
+++ b/public/js/editors/mobileCodeMirror.js
@@ -42,6 +42,7 @@ if (simple || jsbin.mobile || jsbin.tablet || rootClassName.indexOf('ie6') !== -
     setCode: function (code) {
       this.textarea.value = code;
     },
+    getOption: noop,
     getCode: function () {
       return this.textarea.value;
     },


### PR DESCRIPTION
MobileMirror didn't have the getOption method, so it wouldn't complete loading when in textarea mode
