### PR TITLE
Minor a11y changes to views

### DIFF
--- a/views/account.html
+++ b/views/account.html
@@ -6,7 +6,7 @@
   </head>
   <body>
     <form action="{{action}}" method="post">
-      <label for="field-email">New Password</label>
+      <label for="field-email">Email</label>
       <input id="field-email" type="email" name="email" value="{{email}}" />
       <label for="field-password">New Password</label>
       <input id="field-password" type="key" name="key" />

--- a/views/account/editor.html
+++ b/views/account/editor.html
@@ -108,50 +108,50 @@
 
     <div>
       <label for="activeline">Active line</label>
-      <input id="activeline" name="activeline" type="checkbox">
-      <label for="activeline" class="mini-desc">Style the current cursor line</label>
+      <input id="activeline" name="activeline" type="checkbox" aria-describedby="activeline-desc">
+      <div id="activeline-desc" class="mini-desc">Style the current cursor line</div>
     </div>
 
     <div>
       <label for="closebrackets">Close brackets</label>
-      <input id="closebrackets" name="closebrackets" type="checkbox">
-      <label for="closebrackets" class="mini-desc">Auto-close brackets and quotes</label>
+      <input id="closebrackets" name="closebrackets" type="checkbox" aria-describedby="closebrackets-desc">
+      <div id="closebrackets-desc" class="mini-desc">Auto-close brackets and quotes</div>
     </div>
 
     <div>
       <label for="matchbrackets">Match brackets</label>
-      <input id="matchbrackets" name="matchbrackets" type="checkbox">
-      <label for="matchbrackets" class="mini-desc">Highlights matching brackets whenever the cursor is next to them</label>
+      <input id="matchbrackets" name="matchbrackets" type="checkbox" aria-describedby="matchbrackets-desc">
+      <div id="matchbrackets-desc" class="mini-desc">Highlights matching brackets whenever the cursor is next to them</div>
     </div>
 
     <div>
       <label for="highlight">Highlight</label>
-      <input id="highlight" name="highlight" type="checkbox">
-      <label for="highlight" class="mini-desc">Highlight all instances of a currently selected word</label>
+      <input id="highlight" name="highlight" type="checkbox" aria-describedby="highlight-desc">
+      <div id="highlight-desc" class="mini-desc">Highlight all instances of a currently selected word</div>
     </div>
 
     <div>
       <label for="matchtags">Match tags</label>
-      <input id="matchtags" name="matchtags" type="checkbox">
-      <label for="matchtags" class="mini-desc">Highlight matching tags under the cursor (useful with HTML)</label>
+      <input id="matchtags" name="matchtags" type="checkbox" aria-describedby="">
+      <div id="matchtags-desc" class="mini-desc">Highlight matching tags under the cursor (useful with HTML)</div>
     </div>
 
     <div>
       <label for="trailingspace">Trailing space</label>
-      <input id="trailingspace" name="trailingspace" type="checkbox">
-      <label for="trailingspace" class="mini-desc">Visualise trailing whitespace</label>
+      <input id="trailingspace" name="trailingspace" type="checkbox"  aria-describedby="trailingspace-desc">
+      <div id="trailingspace-desc" class="mini-desc">Visualise trailing whitespace</div>
     </div>
 
     <div>
       <label for="fold">Code folding</label>
-      <input id="fold" name="fold" type="checkbox">
-      <label for="fold" class="mini-desc">Fold and unfold matching code blocks</label>
+      <input id="fold" name="fold" type="checkbox" aria-describedby="fold-desc">
+      <div id="fold-desc" class="mini-desc">Fold and unfold matching code blocks</div>
     </div>
 
     <div>
       <label for="tern">Tern</label>
-      <input id="tern" name="tern" type="checkbox">
-      <label for="tern" class="mini-desc"><a href="http://ternjs.net/" target="_blank">Tern.js</a> code-analysis engine (not available in the preview below)</label>
+      <input id="tern" name="tern" type="checkbox" aria-describedby="tern-desc">
+      <div id="tern-desc" class="mini-desc"><a href="http://ternjs.net/" target="_blank">Tern.js</a> code-analysis engine (not available in the preview below)</div>
     </div>
 
   	<input type="hidden" id="_csrf" name="_csrf" value="{{token}}">

--- a/views/index.html
+++ b/views/index.html
@@ -47,7 +47,7 @@ if(top != self) {
     <div class="buttons">
       {{#if embed}}
         <span class="menu">
-          <a target="_blank" href="{{code_id_path}}/edit" class="brand button group"><img src="{{static}}/images/favicon.svg">
+          <a target="_blank" href="{{code_id_path}}/edit" class="brand button group"><img src="{{static}}/images/favicon.svg" alt="">
           <h1>JS Bin</h1></a><a href="/clone" target="_blank" class="button">Save</a>
         </span>
       {{else}}

--- a/views/partials/features.html
+++ b/views/partials/features.html
@@ -1,7 +1,7 @@
 <table id="featureGrid">
   <thead>
     <tr class="headings">
-      <th>&nbsp;</th>
+      <td>&nbsp;</td>
       <th>Anonymous</th>
       <th>Signed-in</th>
       <th>
@@ -24,7 +24,7 @@
     <tr class="{{user}}">
       <td class="feature">
         {{#if tip}}
-        <span tabIndex="1" class="tip" data-tip="{{tip}}">?</span>
+        <span tabIndex="0" class="tip" data-tip="{{tip}}">?</span>
         {{/if}}
         {{name}}
       </td>

--- a/views/register-login.html
+++ b/views/register-login.html
@@ -25,7 +25,7 @@
 
 </div>
 <a class="btn-github" href="{{root}}/auth/github">
-  <img src="{{static}}/images/github-32.png">
+  <img src="{{static}}/images/github-32.png" alt="">
   Login or Register via GitHub
 </a>
 

--- a/views/upgrade.html
+++ b/views/upgrade.html
@@ -21,7 +21,7 @@ ga('send', 'pageview', {
           <h3>1. Sign in</h3>
           <div class="upgrade-signin-wrapper">
             <a class="btn-github" href="{{root}}/auth/github">
-              <img src="{{static}}/images/github-32.png">
+              <img src="{{static}}/images/github-32.png" alt="">
               Login or Register via GitHub
             </a>
             <span class="login-group">


### PR DESCRIPTION
Fixed a small # of missing alt attributes. Images did not convey any information and/or other text adjacent to the image was sufficient, so they were given empty alts.

Changed an empty TH element into TDs. Empty TH elements may be confusing for screen reader users

Changed tabindex="1" to tabindex="0". Tabindex values > 0 become an explicit tab stop. IOW, because the tooltips had tabindex="1" it would take the first position in the tab order.  But, giving it tabindex="0" allows it to take its "natural"  spot in the tab order.

For views/account/editor.html - each field had two labels: 1 intended to be the label and the 2nd intending to be a description.    The problem with using two `label` elements is that screen readers will only read the first one.  IOW, the description isn't read.   The solution: use a `div` with an `id` that can be referenced with `aria-describedby`.  This will reliably allow ARIA-supporting assistive technologies to read the description.

NOTE ON THIS PR: I've not verified that there aren't any (visually) breaking changes. There shouldn't be, because the class names remain unchanged.
