### PR TITLE
Dont use catch method on promises

### DIFF
--- a/public/js/chrome/gist.js
+++ b/public/js/chrome/gist.js
@@ -129,7 +129,7 @@ var Gist = (function () { // jshint ignore:line
           console.groupEnd('gist');
         }
       });
-    }).catch(function (error) {
+    }, function (error) {
       console.error(error.stack);
     });
 

--- a/public/js/render/console.js
+++ b/public/js/render/console.js
@@ -606,7 +606,7 @@ function upgradeConsolePanel(console) {
               });
             }, 0);
           });
-        }).catch(function (error) {
+        }, function (error) {
           console.warn('Failed to render JavaScript');
           console.warn(error);
         });


### PR DESCRIPTION
This blows up IE8 and 9 so we're reverting to the class, comma seperated success
and fail callbacks
