### PR TITLE
Fixed #1929

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -102,7 +102,8 @@ module.exports = function (app) {
 
     if (settings) {
       try {
-        settings = JSON.parse(metadata.settings);
+        // TODO why on earth am I expecting JSON???
+        settings = typeof metadata.settings === 'string' ? JSON.parse(metadata.settings) : metadata.settings;
         ssl = features('sslForAll', { session: { user: { name: metadata.name, pro: metadata.pro, settings: { ssl: settings.ssl }}}});
       } catch (e) {}
     }


### PR DESCRIPTION
Some reason the metadata.settings was already an object, so we were double parsing it, and https wasn't sticking
