### PR TITLE
First pass at aria-label

### DIFF
--- a/views/index.html
+++ b/views/index.html
@@ -341,7 +341,7 @@ if(top != self) {
         </div>
       </div>
       <div class="editbox">
-        <textarea spellcheck="false" autocapitalize="none" autocorrect="off" id="html"></textarea>
+        <textarea aria-label="HTML Code Panel" spellcheck="false" autocapitalize="none" autocorrect="off" id="html"></textarea>
       </div>
     </div>
     <div class="code stretch javascript panel">
@@ -360,7 +360,7 @@ if(top != self) {
         </div>
       </div>
       <div class="editbox">
-        <textarea spellcheck="false" autocapitalize="none" autocorrect="off" id="javascript"></textarea>
+        <textarea aria-label="JavaScript Code Panel" spellcheck="false" autocapitalize="none" autocorrect="off" id="javascript"></textarea>
       </div>
     </div>
     <div class="code stretch css panel">
@@ -380,7 +380,7 @@ if(top != self) {
         </div>
       </div>
       <div class="editbox">
-        <textarea spellcheck="false" autocapitalize="none" autocorrect="off" id="css"></textarea>
+        <textarea aria-label="CSS Code Panel" spellcheck="false" autocapitalize="none" autocorrect="off" id="css"></textarea>
       </div>
     </div>
     <div class="stretch console panel">
@@ -392,7 +392,7 @@ if(top != self) {
         </span>
       </div>
       <div id="console" class="stretch"><ul id="output"></ul><form>
-          <textarea id="exec" spellcheck="false" autocapitalize="none" rows="1" autocorrect="off"></textarea>
+          <textarea aria-label="Console Panel" id="exec" spellcheck="false" autocapitalize="none" rows="1" autocorrect="off"></textarea>
       </form></div>
     </div>
     <div id="live" class="stretch live panel">


### PR DESCRIPTION
I ran this with both textarea mode _and_ CodeMirror mode and the label remains in place after CodeMirror has finished loading.

I'm not 100% sure how the screen reader is going to use the aria label for this textarea (equally, I'm not sure how a screen reader is going to use CodeMirror in the first place).

Input welcome.

ref #1923
