### PR TITLE
Allow keyboard control

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1698,7 +1698,7 @@ textarea:focus {
   /* font-size: 1em; */
 }
 .help a {
-  outline: 0;
+  /*outline: 0;*/
   /*border-right: 0;*/
 }
 
@@ -1947,7 +1947,7 @@ a.button:focus { /* , .button:active */
      -moz-box-shadow: #C8C8C8 0 0 3px;
           box-shadow: #C8C8C8 0 0 3px;
   border-color: #fff;
-  outline: 0;
+  /*outline: 0;*/
   text-shadow: none;
 }
 
@@ -2240,13 +2240,15 @@ body.preview #source select {
   left: 0.8em;
   right: 0.8em;
 }
-.mobile .editbox textarea,
-.ie6 .editbox textarea,
-.ie7 .editbox textarea {
+.editbox textarea {
+  tab-size: 4; /* because 12 spaces is silly */
+  -moz-tab-size: 4;
+  -o-tab-size: 4;
+  white-space: pre-wrap;
   margin: 0;
   border: 0;
-  font-family: Menlo, Monaco, consolas, monospace;
   color: black;
+  background: #fff;
   padding: 0;
   font-size: 12px;
   position: absolute;
@@ -2260,8 +2262,7 @@ body.preview #source select {
   height: 100%;
 }
 
-.ie6 textarea,
-.ie7 textarea {
+.editbox textarea {
   width: 100%;
   height: 100%;
 }
@@ -2996,7 +2997,7 @@ input {
   font-size: 14px;
 }
 #bin .editbox .CodeMirror pre,
-.mobile textarea {
+.editbox textarea {
   font-family: SourceCodeProRegular, Menlo, Monaco, consolas, monospace;
 }
 

--- a/public/js/chrome/navigation.js
+++ b/public/js/chrome/navigation.js
@@ -144,7 +144,18 @@ function closedropdown() {
   }
 }
 
-var dropdownButtons = $('.button-dropdown, .button-open').mousedown(function (e) {
+var dropdownButtons = $('.button-dropdown, .button-open').on('mousedown keydown', function (e) {
+  if (e.type === 'keydown') {
+    if (e.which === 13 || e.which === 32) { // enter or space
+      if (dropdownOpen && dropdownOpen === this) {
+        closedropdown();
+        return;
+      } // else: open dropdown
+    } else {
+      return;
+    }
+  }
+
   $dropdownLinks.removeClass('hover');
   if (dropdownOpen && dropdownOpen !== this) {
     closedropdown();

--- a/public/js/chrome/welcome-panel.js
+++ b/public/js/chrome/welcome-panel.js
@@ -2,7 +2,9 @@
   /*global jsbin, $, $body, $document, analytics, settings*/
   'use strict';
 
-  if (!$('#toppanel').length) {
+  var $toppanel = $('#toppanel');
+
+  if (!$toppanel.length) {
     return;
   }
 
@@ -28,6 +30,8 @@
     $body.addClass('toppanel-close');
     $body.removeClass('toppanel');
 
+    $toppanel.trigger('close');
+
     // $document.trigger('sizeeditors');
   };
 
@@ -36,6 +40,8 @@
     settings.save();
     $body.removeClass('toppanel-close');
     $body.addClass('toppanel');
+
+    $toppanel.trigger('open');
   };
 
   var goSlow = function(e) {
@@ -129,7 +135,7 @@
   })
 
   // analytics for links
-  $('#toppanel').find('.toppanel-link').mousedown(function() {
+  $toppanel.find('.toppanel-link').mousedown(function() {
     analytics.welcomePanelLink(this.href);
   });
 

--- a/public/js/editors/focus.js
+++ b/public/js/editors/focus.js
@@ -1,0 +1,137 @@
+(function () {
+  'use strict';
+
+  var esc = 27;
+  var tab = 9;
+  var f9 = 120;
+  var up = 38;
+  var down = 40;
+
+  function insertTab(event) {
+    var el = event.target;
+    var start = el.selectionStart;
+    var end = el.selectionEnd;
+
+    var target = el;
+    var value = target.value;
+
+    // set textarea value to: text before caret + tab + text after caret
+    target.value = value.substring(0, start) + '\t' + value.substring(end);
+
+    // put caret at right position again (add one for the tab)
+    el.selectionStart = el.selectionEnd = start + 1;
+  }
+
+  $('.panel').on('keydown', 'textarea', function (event) {
+    var which = event.which;
+    // if (which === esc) {
+    //   $(this).closest('.panel').focus();
+    //   return false;
+    // }
+
+    if (jsbin.lameEditor && which === tab) {
+      insertTab(event);
+      return false;
+    }
+
+    if (which === f9) {
+      $('#panels a:first').focus();
+      return false;
+    }
+  });
+
+  var oldFocusPanel = null;
+  $('.menu').on('open', function () {
+    // enable tab focus when menu is opened
+    oldFocusPanel = document.activeElement;
+    $(this).find('.dropdown a').attr('tabindex', 0).filter(':first').focus();
+  }).on('close', function () {
+    // and disable (tabindex=-1) when closed
+    $(this).find('.dropdown a').attr('tabindex', -1);
+    if (oldFocusPanel) {
+      oldFocusPanel.focus();
+    }
+  }).trigger('close').on('keydown', function (event) {
+    var which = event.which;
+
+    if (which === up) {
+      var $focused = $(document.activeElement).removeClass('hover');
+      var $links = $focused.prevAll('a:visible');
+      $links.eq(0).focus().addClass('hover');
+    } else if (which === down) {
+      var $focused = $(document.activeElement).removeClass('hover');
+      var $links = $focused.nextAll('a:visible');
+      $links.eq(0).focus().addClass('hover');
+    }
+  });
+
+  var $toppanel = $('#toppanel').on('open', function () {
+    $toppanel.find('a').attr('tabindex', 0);
+  }).on('close', function () {
+    $toppanel.find('a').filter(function () {
+      return this.className !== 'toppanel-logo';
+    }).attr('tabindex', -1);
+  });
+
+  if (true) { // debug information
+    var $active = $('<pre></pre>').css({
+      position: 'absolute',
+      right: 20,
+      bottom: 20,
+      margin: 0,
+      zIndex: 10000,
+      fontSize: 12,
+      padding: 5,
+      color: '#fff',
+      borderRadius: 3,
+      background: '#aaa',
+      overflow: 'hidden',
+      maxWidth: '95%',
+      textOverflow: 'ellipsis',
+    }).attr('tabindex', -1).appendTo('body').focus(function () {
+      $active.css({
+        overflow: 'auto',
+        whiteSpace: 'pre-wrap',
+      });
+    }).blur(function () {
+      $active.css({
+        overflow: 'hidden',
+        whiteSpace: 'pre',
+      });
+    });
+
+    var lastActive = null;
+
+    var showActive = function () {
+      var el = document.activeElement;
+      var html;
+      var attrs;
+      var i = 0;
+
+      if (el !== lastActive && el !== $active[0]) {
+        lastActive = el;
+        html = '<' + el.nodeName.toLowerCase();
+        attrs = el.attributes;
+
+        for (i = 0; i < attrs.length; i++) {
+          html += ' ' + attrs[i].name + '="' + attrs[i].value + '"';
+        }
+
+        html += '>';
+
+        $active.text(html);
+      }
+
+      requestAnimationFrame(showActive);
+    }
+
+    showActive();
+  }
+
+  if ($('body').hasClass('toppanel')) {
+    $toppanel.trigger('open');
+  } else {
+    $toppanel.trigger('close');
+  }
+
+})();

--- a/public/js/editors/mobileCodeMirror.js
+++ b/public/js/editors/mobileCodeMirror.js
@@ -20,8 +20,12 @@ if (simple || jsbin.mobile || jsbin.tablet || rootClassName.indexOf('ie6') !== -
     this.textarea.style.opacity = 1;
     // this.textarea.style.width = '100%';
 
+    var old = this.value;
     $(this.textarea)[jsbin.mobile || jsbin.tablet ? 'blur' : 'keyup'](throttle(function () {
-      $(document).trigger('codeChange', { panelId: el.id });
+      if (old !== this.value) {
+        old = this.value;
+        $(document).trigger('codeChange', { panelId: el.id });
+      }
     }, 200));
 
     options.initCallback && $(options.initCallback);

--- a/scripts.json
+++ b/scripts.json
@@ -38,6 +38,7 @@
     "/js/render/render.js",
     "/js/render/live.js",
     "/js/editors/keycontrol.js",
+    "/js/editors/focus.js",
     "/js/render/console.js",
     "/js/processors/processor.js",
     "/js/editors/panel.js",

--- a/views/index.html
+++ b/views/index.html
@@ -132,7 +132,7 @@ if(top != self) {
           <a href="{{code_id_path}}/save" class="save button group">Start saving your work</a>
         </div>
       {{/if}}
-      <div id="panels"></div>
+      <div id="panels" aria-label="Panels"></div>
       <div class="help">
         {{#unless embed}}
           {{#if home}}
@@ -339,7 +339,7 @@ if(top != self) {
   <div id="source" class="binview stretch">
   </div>
   <div id="panelswaiting">
-    <div class="code stretch html panel">
+    <div class="code stretch html panel" tabindex="0">
       <div class="label menu"><span class="name"><strong><a href="#htmlprocessors" class="fake-dropdown button-dropdown">HTML</a></strong></span><div class="dropdown" id="htmlprocessors">
           <div class="dropdownmenu processorSelector" data-type="html">
             <a href="#html">HTML</a>
@@ -353,7 +353,7 @@ if(top != self) {
         <textarea aria-label="HTML Code Panel" spellcheck="false" autocapitalize="none" autocorrect="off" id="html"></textarea>
       </div>
     </div>
-    <div class="code stretch javascript panel">
+    <div class="code stretch javascript panel" tabindex="0">
       <div class="label menu"><span class="name"><strong><a  class="fake-dropdown button-dropdown" href="#javascriptprocessors">JavaScript</a></strong></span>
         <div class="dropdown" id="javascriptprocessors">
           <div class="dropdownmenu processorSelector" data-type="javascript">
@@ -372,7 +372,7 @@ if(top != self) {
         <textarea aria-label="JavaScript Code Panel" spellcheck="false" autocapitalize="none" autocorrect="off" id="javascript"></textarea>
       </div>
     </div>
-    <div class="code stretch css panel">
+    <div class="code stretch css panel" tabindex="0">
       <div class="label menu"><span class="name"><strong><a class="fake-dropdown button-dropdown" href="#cssprocessors">CSS</a></strong></span>
         <div class="dropdown" id="cssprocessors">
           <div class="dropdownmenu processorSelector" data-type="css">
@@ -392,7 +392,7 @@ if(top != self) {
         <textarea aria-label="CSS Code Panel" spellcheck="false" autocapitalize="none" autocorrect="off" id="css"></textarea>
       </div>
     </div>
-    <div class="stretch console panel">
+    <div class="stretch console panel" tabindex="0">
       <div class="label">
         <span class="name"><strong>Console</strong></span>
         <span class="options">
@@ -404,7 +404,7 @@ if(top != self) {
           <textarea aria-label="Console Panel" id="exec" spellcheck="false" autocapitalize="none" rows="1" autocorrect="off"></textarea>
       </form></div>
     </div>
-    <div id="live" class="stretch live panel">
+    <div id="live" class="stretch live panel" tabindex="0">
       <div class="label">
         <span class="name"><strong>Output</strong></span>
         <span class="options">

--- a/views/partials/welcome-panel.html
+++ b/views/partials/welcome-panel.html
@@ -1,7 +1,7 @@
 <div id="toppanel" class="toppanel-wrapper" style="display:none;">
   <div class="toppanel-column toppanel-column-first">
     <a href="#" class="toppanel-hide" title="Close">Close welcome panel</a>
-    <a href="#" class="toppanel-logo">
+    <a href="#" aria-label="Toggle introduction content" class="toppanel-logo">
       <img src="{{static}}/images/dave.min.svg" alt="Welcome to JS Bin">
     </a>
     <div class="toppanel-actions{{#unless home}} toppanel-actions-alone{{/unless}}">


### PR DESCRIPTION
- [ ] Ready to merge

The start of making JS Bin fully keyboard accessible.
- Restore focus style
- Dynamically change tabindex depending on whether the menu (or welcome panel) is open or not
- Allow F9 to focus _out_ of editor to the panel selection tool (by default it focuses to the first panel button: html) - fixes #1936 
- WIP
- [ ] Aria roles and states
- [ ] Solution for menu items with input elements
