### PR TITLE
Only selectAll if there's console content

### DIFF
--- a/public/js/render/console.js
+++ b/public/js/render/console.js
@@ -403,11 +403,14 @@ function whichKey(event) {
 
 function setCursorTo(str) {
   str = enableCC ? cleanse(str) : str;
+  var old = exec.value;
   exec.value = str;
 
   if (enableCC) {
-    document.execCommand('selectAll', false, null);
-    document.execCommand('delete', false, null);
+    if (exec.textContent.length) {
+      document.execCommand('selectAll', false, null);
+      document.execCommand('delete', false, null);
+    }
     document.execCommand('insertHTML', false, str);
     getCursor().focus();
   } else {


### PR DESCRIPTION
Because this causes the entire page to be selected when it's loading :-\

Fixes #1979
