### PR TITLE
If no HTML, don't add try/catch

### DIFF
--- a/public/js/render/render.js
+++ b/public/js/render/render.js
@@ -117,7 +117,9 @@ var getPreparedCode = (function () {
       // aren't useful (Script error. (line 0) #1354) so we try/catch and then
       // throw the real error. This also works exactly as expected with non-
       // processed JavaScript
-      js = 'try {' + js + '\n} catch (error) { throw error; }';
+      if (hasHTML) {
+        js = 'try {' + js + '\n} catch (error) { throw error; }';
+      }
 
       // Rewrite loops to detect infiniteness.
       // This is done by rewriting the for/while/do loops to perform a check at


### PR DESCRIPTION
Although this doesn't cause any halm, it might confuse users as to why it's there, so it's being hidden when there's no HTML.

Arguably we might have to go further and not replace the console logging, but let's land this first.

Fixes #1983
