### PR TITLE
Custom key settings could not be read when anon

### DIFF
--- a/public/js/editors/keycontrol.js
+++ b/public/js/editors/keycontrol.js
@@ -1,7 +1,7 @@
 /*globals objectValue, $, jsbin, $body, $document*/
 var keyboardHelpVisible = false;
 
-var customKeys = objectValue('jsbin.settings.keys') || {};
+var customKeys = objectValue('settings.keys', jsbin) || {};
 
 function enableAltUse() {
   if (!jsbin.settings.keys) {


### PR DESCRIPTION
We were trying to read the jsbin object of the window object, but since we made the entire thing private a few months ago, this started breaking.

So now I pass in the correct context to the read the object.

Fixes #1987
