### PR TITLE
Remove <base>

### DIFF
--- a/public/js/runner/processor.js
+++ b/public/js/runner/processor.js
@@ -74,11 +74,6 @@ var processor = (function () {
     source = doctypeObj.tail;
     combinedSource.push(doctype);
 
-    // this ensures that requests are bounced away from
-    // jsbin when they're relative. They shouldn't be
-    // hitting jsbin directly for broken images, etc.
-    combinedSource.push('<base href="//null.jsbin.com/">');
-
     // Kill the blocking functions
     // IE requires that this is done in the script, rather than off the window
     // object outside of the doc.write.


### PR DESCRIPTION
Note: this doesn't remove the null domain, this is now set as the runner: null.jsbin.com - but null.jsbin.com/runner _does_ serve the correct file, and everything is else returned a 204 - so we're still protected.

Fixes #1896
Fixes #1954
Fixes #2012
