### PR TITLE
Update Bootstrap latest to 3.3.0 version. Closes #2096

### DIFF
--- a/public/js/editors/libraries.js
+++ b/public/js/editors/libraries.js
@@ -108,8 +108,8 @@ var libraries = [
   {
     'url': [
       '//code.jquery.com/jquery.min.js',
-      '//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css',
-      '//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js'
+      '//maxcdn.bootstrapcdn.com/bootstrap/3.3.0/css/bootstrap.min.css',
+      '//maxcdn.bootstrapcdn.com/bootstrap/3.3.0/js/bootstrap.min.js'
     ],
     'label': 'Bootstrap Latest',
     'group': 'Bootstrap'


### PR DESCRIPTION
This PR updates Bootstrap 3 library used on jsbin.com to version 3.3.0 that's been just released:
[Bootstrap 3.3.0 released](http://blog.getbootstrap.com/2014/10/29/bootstrap-3-3-0-released/)

This PR was verified on local instance of jsbin.com:
![20141030192900](https://cloud.githubusercontent.com/assets/14539/4849567/ad22f082-6062-11e4-93f1-c0968609e78b.jpg)
