### PR TITLE
Update URLs to WIP jQuery versions; account for the jQuery 1.x -> jQuery Compat rename

### DIFF
--- a/public/js/editors/libraries.js
+++ b/public/js/editors/libraries.js
@@ -1,7 +1,7 @@
 var libraries = [
   {
-    'url': '//code.jquery.com/jquery-git2.js',
-    'label': 'jQuery 2.x WIP (via git)',
+    'url': '//code.jquery.com/jquery-git.js',
+    'label': 'jQuery WIP (via git)',
     'group': 'jQuery'
   },
   {
@@ -10,8 +10,8 @@ var libraries = [
     'group': 'jQuery'
   },
   {
-    'url': '//code.jquery.com/jquery-git1.js',
-    'label': 'jQuery 1.x WIP (via git)',
+    'url': '//code.jquery.com/jquery-compat-git.js',
+    'label': 'jQuery Compat WIP (via git)',
     'group': 'jQuery'
   },
   {


### PR DESCRIPTION
Fix #2115
