### PR TITLE
sqlite adapter currently fails to obtain bin when pulling a specific revision

### DIFF
--- a/lib/db/sqlite.js
+++ b/lib/db/sqlite.js
@@ -34,7 +34,7 @@ module.exports = utils.inherit(Object, {
     fn();
   },
   getBin: function (params, fn) {
-    var values = [params.id, params.revision],
+    var values = [params.id, params.revision, params.revision],
         _this = this;
 
     this.connection.get(templates.getBin, values, function (err, result) {


### PR DESCRIPTION
The `getBin` function has been failing in sqlite since a3c608e05c863b23f3f066ed4cc5e951b739cc56, as only one of the revision parameters is being bound. This means any bin URL with a specific revision would return 0 results and show a blank bin.

This is a fix modeled after  `mysql.js`.
