### PR TITLE
Better support for jsbin running under a URL prefix

### DIFF
--- a/views/account/logout.html
+++ b/views/account/logout.html
@@ -2,7 +2,7 @@
 
 <h1>Logging out...</h1>
 
-<form method="post" action="/logout">
+<form method="post" action="{{root}}/logout">
 <input type="hidden" name="_csrf" value="{{token}}">
 </form>
 

--- a/views/index.html
+++ b/views/index.html
@@ -49,7 +49,7 @@ if(top != self) {
       {{#if embed}}
         <span class="menu">
           <a target="_blank" href="{{code_id_path}}/edit" class="brand button group"><img src="{{static}}/images/favicon.svg" alt="">
-          <h1>JS Bin</h1></a><a href="/clone" target="_blank" class="button">Save</a>
+            <h1>JS Bin</h1></a><a href="{{root}}/clone" target="_blank" class="button">Save</a>
         </span>
       {{else}}
         <div class="menu">
@@ -216,16 +216,16 @@ if(top != self) {
                   </span>
 
                   <ul>
-                    <li><a href="/account/profile">Profile</a></li>
-                    <li><a href="/account/editor">Editor settings</a></li>
-                    <li><a href="/account/preferences">Preferences</a></li>
-                    <li><a href="/logout">Logout</a></li>
+                    <li><a href="{{root}}/account/profile">Profile</a></li>
+                    <li><a href="{{root}}/account/editor">Editor settings</a></li>
+                    <li><a href="{{root}}/account/preferences">Preferences</a></li>
+                    <li><a href="{{root}}/logout">Logout</a></li>
                   </ul>
 
                 </div>
                 {{#feature request "upgrade"}}
                   {{#unless user.pro}}
-                <a href="/upgrade" class="gopro">Support JS Bin: upgrade to PRO</a>
+                  <a href="{{root}}/upgrade" class="gopro">Support JS Bin: upgrade to PRO</a>
                   {{/unless}}
                 {{/feature}}
               </div>
@@ -257,7 +257,7 @@ if(top != self) {
                     {{#feature request "github"}}{{#unless user.github_token}}
                     <div>
                       <span class="login-splitter">or</span>
-                      <a class="btn-github" href="/auth/github"><img src="{{static}}/images/github-32.png"> Link your Github account</a>
+                      <a class="btn-github" href="{{root}}/auth/github"><img src="{{static}}/images/github-32.png"> Link your Github account</a>
                     </div>
                     {{/unless}}{{/feature}}
                   </form>
@@ -277,7 +277,7 @@ if(top != self) {
                 <a href="{{root}}/login" class="button button-dropdown focusbtn" id="loginbtn">Login or Register</a>
                 <div class="dropdown login" id="registerLogin">
                   <div class="dropdowncontent">
-                    <a class="btn-github" href="/auth/github">
+                    <a class="btn-github" href="{{root}}/auth/github">
                       <img src="{{static}}/images/github-32.png">
                       Login or Register via GitHub
                     </a>
@@ -324,7 +324,7 @@ if(top != self) {
                     {{#feature request "github"}}
                     <div>
                       <span class="login-splitter">or</span>
-                      <a title="To sign in using Github and export gists to your Github profile" class="btn-github" href="/auth/github"><img src="{{static}}/images/github-32.png"> Sign in with Github</a>
+                      <a title="To sign in using Github and export gists to your Github profile" class="btn-github" href="{{root}}/auth/github"><img src="{{static}}/images/github-32.png"> Sign in with Github</a>
                     </div>
                     {{/feature}}
                   </form>
@@ -354,7 +354,7 @@ if(top != self) {
                     {{#feature request "github"}}
                     <div>
                       <span class="login-splitter">or</span>
-                      <a class="btn-github" href="/auth/github"><img src="{{static}}/images/github-32.png"> Register with Github</a>
+                      <a class="btn-github" href="{{root}}/auth/github"><img src="{{static}}/images/github-32.png"> Register with Github</a>
                     </div>
                     {{/feature}}
                   </form>
@@ -557,7 +557,7 @@ Include alerts, prompts &amp; confirm boxes">Run with JS</button>
           <td>ctrl + y</td>
           <td>Archive Bin</td>
         </tr>
-        <tr><td colspan="2"><small><br><a href="/help/keyboard-shortcuts" target="_blank">Complete list of JS Bin shortcuts</a></small></td></tr>
+        <tr><td colspan="2"><small><br><a href="{{root}}/help/keyboard-shortcuts" target="_blank">Complete list of JS Bin shortcuts</a></small></td></tr>
       </tbody>
     </table>
   </div>

--- a/views/login.html
+++ b/views/login.html
@@ -1,10 +1,10 @@
 <link rel="stylesheet" href="/css/login.css">
 <div class="form-container">
   <div class="tabs">
-    <a class="tab tab-selected" href="/login">Login</a>
+    <a class="tab tab-selected" href="{{root}}/login">Login</a>
     <a class="tab" href="/register">Signup</a>
   </div>
-  <form action="/login" method="post" class="login">
+  <form action="{{root}}/login" method="post" class="login">
     <div>
       <label>Username or Email<br>
       <input name="username" type="text"></label>
@@ -20,6 +20,6 @@
     </div>
   </form>
 </div>
-<link rel="stylesheet" href="/css/login.css">
-<script src="/js/vendor/jquery-1.11.0.min.js"></script>
-<script src="/js/chrome/login.js"></script>
+<link rel="stylesheet" href="{{static}}/css/login.css">
+<script src="{{static}}/js/vendor/jquery-1.11.0.min.js"></script>
+<script src="{{static}}/js/chrome/login.js"></script>


### PR DESCRIPTION
A few of the URLs are missing `{{root}}` or other URL prefixes, which causes failure when running with `url.prefix` configured.

Some of these changes are the non-controversial bits from #1450. I'd be willing to take that out and treat it as a separate PR if it needs further discussion.
