### PR TITLE
Make sure HTML editor is visible when adding description. Fixes #2163

### DIFF
--- a/public/js/chrome/navigation.js
+++ b/public/js/chrome/navigation.js
@@ -426,6 +426,10 @@ $('#addmeta').click(function () {
       cm = editor.editor,
       html = editor.getCode();
 
+  if (!editor.visible) {
+    editor.show();
+  }
+
   if (!re.meta.test(html)) {
     if (re.head.test(html)) {
       html = html.replace(re.head, '<head$1\n' + metatag);


### PR DESCRIPTION
[UX] Make sure that HTML editor is visible when adding meta tag
description text from _Add description_ menu action.
Avoids situation that "Add description" seems to have no visible
results for novice users.

``` bash
npm test
[...]
    ✓ should protect do loops 

  labels
    ✓ should handle continue statements and gotos 
    ✓ should handle labels with comments 
    ✓ should handle things that *look* like labels 


  22 passing (8s)
```
