### PR TITLE
Update Bootstrap latest to 3.3.1 version. Closes #2165

### DIFF
--- a/public/js/editors/libraries.js
+++ b/public/js/editors/libraries.js
@@ -108,8 +108,8 @@ var libraries = [
   {
     'url': [
       '//code.jquery.com/jquery.min.js',
-      '//maxcdn.bootstrapcdn.com/bootstrap/3.3.0/css/bootstrap.min.css',
-      '//maxcdn.bootstrapcdn.com/bootstrap/3.3.0/js/bootstrap.min.js'
+      '//maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.min.css',
+      '//maxcdn.bootstrapcdn.com/bootstrap/3.3.1/js/bootstrap.min.js'
     ],
     'label': 'Bootstrap Latest',
     'group': 'Bootstrap'


### PR DESCRIPTION
This is purely maintenance kind of PR.
Keeps version of Bootstrap used in JSBin in sync with latest 3.3.1
version.
http://blog.getbootstrap.com/2014/11/12/bootstrap-3-3-1-released/

Tests:
https://gist.github.com/peterblazejewicz/7e96aadf78f1ac47787d

Thanks!
