### PR TITLE
Add explicit link to exit history view. Closes #2177

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -3738,6 +3738,17 @@ left: 50%;
   float: left;
 }
 
+#history .header a {
+  color: rgb(161, 216, 253);
+  font-weight: inherit;
+}
+
+#history .header a:active,
+#history .header a:hover,
+#history .header a:focus {
+  text-decoration: underline;
+}
+
 #history h2 {
   margin: 0;
   font-family: "Helvetica Neue", Helvetica, Arial;

--- a/public/js/render/saved-history-preview.js
+++ b/public/js/render/saved-history-preview.js
@@ -141,6 +141,10 @@
 
       event.preventDefault();
       event.stopPropagation(); // prevent further delegates
+      if ($this.data('toggle') === 'history') {
+        window.location.reload();
+        return;
+      }
       var $tr = $this.closest('tr');
       var data = $tr.data();
       var url = jsbin.root + data.url;

--- a/views/history.html
+++ b/views/history.html
@@ -1,6 +1,6 @@
 <div id="history">
   <div class="header">
-    <h2>Open previously saved <em>bins</em>{{by_user}}:</h2>
+    <h2>Open previously saved <em>bins</em>{{by_user}} or <a href="#" data-toggle="history">continue with current one</a>:</h2>
     <div class="menu">
       <input type="checkbox" name="toggle_archive" id="toggleArchive" class="toggle_archive"> <label for="toggleArchive">Archive view</label>
     </div>


### PR DESCRIPTION
This PR adds explicit link to history view header to clearly hint users how to exit current view. This PR uses data-api Bootstrap like data attribute that could be useful in future implementation to toggle history view. At this moment data toggle attribute is used to catch element click in general click handler in history view client code. This attribute seems to be not used in other places yet. The color is copied literally from `.url` class used on this view.

As I was not able to find clear way of using JSBin code:

``` JavaScript
jsbin.getURL({withRevision: true})
```

to get current bin url I've used `window.location.reload()` used in other places in JSBin client code.

This commit:
- adds link markup in history view header
- adds style to link similar to .url class
- adds JS to reload current view

![20141211230852](https://cloud.githubusercontent.com/assets/14539/5403221/6b97bf90-818b-11e4-9cc3-6b46f8421331.jpg)
