### PR TITLE
Use *latest* url for Bootstrap library. Closes #2238

### DIFF
--- a/public/js/editors/libraries.js
+++ b/public/js/editors/libraries.js
@@ -108,8 +108,8 @@ var libraries = [
   {
     'url': [
       '//code.jquery.com/jquery.min.js',
-      '//maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.min.css',
-      '//maxcdn.bootstrapcdn.com/bootstrap/3.3.1/js/bootstrap.min.js'
+      '//maxcdn.bootstrapcdn.com/bootstrap/latest/css/bootstrap.min.css',
+      '//maxcdn.bootstrapcdn.com/bootstrap/latest/js/bootstrap.min.js'
     ],
     'label': 'Bootstrap Latest',
     'group': 'Bootstrap'


### PR DESCRIPTION
This PR changes bootstrapcdn url from user version links to `latest` symlink:
https://github.com/MaxCDN/bootstrap-cdn/blob/develop/public/twitter-bootstrap/latest

After this change the Bootstrap latest will be added as:
```html
<link href="//maxcdn.bootstrapcdn.com/bootstrap/latest/css/bootstrap.min.css" rel="stylesheet" type="text/css" />
<script src="//maxcdn.bootstrapcdn.com/bootstrap/latest/js/bootstrap.min.js"></script>
```
This will remove requirement to update Bootstrap to match most recent release.
Tested in local development mode.
Thanks!
