### PR TITLE
Add support for ClojureScript

### DIFF
--- a/public/js/editors/libraries.js
+++ b/public/js/editors/libraries.js
@@ -107,6 +107,13 @@ var libraries = [
   },
   {
     'url': [
+      '//himera-emh.herokuapp.com/js/repl.js'
+    ],
+    'label': 'ClojureScript',
+    'group': 'ClojureScript'
+  },
+  {
+    'url': [
       '//code.jquery.com/jquery.min.js',
       '//maxcdn.bootstrapcdn.com/bootstrap/3.3.2/css/bootstrap.min.css',
       '//maxcdn.bootstrapcdn.com/bootstrap/3.3.2/js/bootstrap.min.js'

--- a/public/js/processors/processor.js
+++ b/public/js/processors/processor.js
@@ -580,22 +580,18 @@ var processors = jsbin.processors = (function () {
       id: 'clojurescript',
       target: 'javascript',
       extensions: ['clj', 'cljs'],
-      //url: jsbin.static + '/js/vendor/clojurescript.js',
       url: "http://himera-emh.herokuapp.com/js/repl.js",
       //url: "http://192.168.100.128:8080/js/repl.js",
       init: function clojurescript(ready) {
         getScript(jsbin.static + '/js/vendor/codemirror4/mode/clojure/clojure.js', ready);
       },
       handler: throttle(debounceAsync(function (source, resolve, reject, done) {
-        console.log("making clojure ajax request");
         $.ajax({
           type: 'post',
           url: 'http://himera-emh.herokuapp.com/compile',
-          //url: "http://192.168.100.128:8080/compile",
           contentType: "application/clojure",
-          data: "{ :expr " + source + " }",
+          data: "{ :expr (let [] (ns cljs.user) " + source + ") }",
           success: function (data) {
-            console.log("clojure data", data)
             var result = cljs.reader.read_string(data);
             result = (new cljs.core.Keyword("\uFDD0:js")).call(null, result);
             if (result) {

--- a/views/index.html
+++ b/views/index.html
@@ -427,6 +427,7 @@ if(top != self) {
             <a href="#typescript">TypeScript</a>
             <a href="#processing">Processing</a>
             <a href="#livescript">LiveScript</a>
+            <a href="#clojurescript">ClojureScript</a>
             <a href="#convert">Convert to JavaScript</a>
           </div>
         </div>


### PR DESCRIPTION
It is implemented via compiler as a service at http://himera-emh.herokuapp.com/ since ClojureScript compiler depends on Java. While there was a port of ClojureScript in ClojureScript it is not up to date. I will think about adding Wisp support also in the future, which is a ClojureScript subset in JavaScript.

It works, but error handling is not perfect at the moment and ClojureScript library has to be added as a separate step via the library dropdown list.
We don't get line and column from ClojureScript compiler.
After I get a ClojureScript compile error and then fix it then the error list is spammed with (presumably) JavaScript errors for some reason.