### PR TITLE
Add API endpoint to get title + desc for users

### DIFF
--- a/lib/custom.js
+++ b/lib/custom.js
@@ -94,6 +94,6 @@ if (config.whiteLabel) {
 
     module.exports = { default: extracted };
   } catch (e) {
-    console.warn('Unable to load custom config: %s', json);
+    console.warn('Unable to load custom config: %s', e.message);
   }
 }

--- a/lib/db/file.js
+++ b/lib/db/file.js
@@ -187,6 +187,9 @@ module.exports = utils.inherit(Object, {
       isowner: true
     });
   },
+  getUserListing: function (user, fn) {
+    fn(null, null);
+  },
   getUserBinCount: function (id, cb) {
     cb(null, { total: 0 }); // TODO read directory for count
   },

--- a/lib/db/mysql.js
+++ b/lib/db/mysql.js
@@ -490,6 +490,10 @@ module.exports = utils.inherit(Object, {
     var sql = templates.getCustomerByStripeId;
     this.connection.query(sql, [id], fn);
   },
+  getUserListing: function (user, fn) {
+    var sql = templates.userListing;
+    this.connection.query(sql, [user], fn);
+  },
   getCustomerByUser: function(user, fn) {
     var sql = templates.getCustomerByUser;
     this.connection.query(sql, [user.name], function(err, result) {

--- a/lib/db/sql_templates.json
+++ b/lib/db/sql_templates.json
@@ -52,6 +52,7 @@
   "getAssetsForUser": "SELECT * FROM assets WHERE `username`=?",
   "deleteAsset": "DELETE FROM assets WHERE `asset_url`=? AND `username`=?",
   "saveAsset": "INSERT INTO assets (`username`, `asset_url`, `size`, `mime`) VALUES (?,?,?,?)",
+  "userListing": "SELECT s.url, s.revision, s.created, s.settings FROM `owners` AS `o`, `sandbox` AS `s` WHERE o.name=? AND s.revision=o.revision AND s.url=o.url",
   "sandboxColumns": [
     "created",
     "last_viewed",

--- a/lib/db/sqlite.js
+++ b/lib/db/sqlite.js
@@ -560,6 +560,10 @@ module.exports = utils.inherit(Object, {
   setCustomerActive: noop,
   getCustomerByStripeId: noop,
   getCustomerByUser: noop,
+  getUserListing: function (user, fn) {
+    var sql = templates.userListing;
+    this.connection.get(sql, [user], fn);
+  },
   setProAccount: function(id, pro, fn){
     this.connection.run(templates.setProAccount, [pro, new Date(), id], fn);
   },

--- a/lib/handlers/bin.js
+++ b/lib/handlers/bin.js
@@ -1152,9 +1152,7 @@ module.exports = Observable.extend({
   renderDetailedHistory: function (req, res, next, bins) {
     var helpers = this.helpers;
     this.formatHistory(bins, function (bin, map) {
-      var settings = bin.settings || {};
-
-      console.log(bin);
+      var settings = bin.settings ? JSON.parse(bin.settings) : {};
 
       return {
         code: bin.url,

--- a/lib/handlers/bin.js
+++ b/lib/handlers/bin.js
@@ -391,18 +391,29 @@ module.exports = Observable.extend({
       return next(404);
     }
 
+    var callback = this.renderHistory.bind(this);
+    var dbMethod = 'getBins';
+
+    var acceptsJSON = req.header('Accept', '').indexOf('application/json') > -1;
+
+    // only support details for ajax requests
+    if (req.query.detailed && acceptsJSON) {
+      callback = this.renderDetailedHistory.bind(this)
+      dbMethod = 'getUserListing';
+    };
+
     // TODO: convert to promise
     this.models.user.load(username, function (error, user) {
       if (error || !user) {
         return next(404);
       }
 
-      this.models.user.getBins(req.params.user || req.session.user.name, function (err, bins) {
+      this.models.user[dbMethod](req.params.user || req.session.user.name, function (err, bins) {
         if (err) {
           return next(404);
         }
 
-        this.renderHistory(req, res, next, bins);
+        callback(req, res, next, bins);
       }.bind(this));
     }.bind(this), true);
     // ^^^^ indicates we want to only check by username (and don't bother email check)
@@ -1138,6 +1149,29 @@ module.exports = Observable.extend({
       res.redirect(303, editPermalink);
     }
   },
+  renderDetailedHistory: function (req, res, next, bins) {
+    var helpers = this.helpers;
+    this.formatHistory(bins, function (bin, map) {
+      var settings = bin.settings || {};
+
+      console.log(bin);
+
+      return {
+        code: bin.url,
+        revision: bin.revision,
+        title: settings.title,
+        description: settings.description,
+        url: helpers.urlForBin(bin),
+        last_updated: bin.created.toISOString(),
+        pretty_last_updated: utils.since(bin.created)
+      };
+    }, function (error, bins) {
+      if (error) {
+        return res.send(error);
+      }
+      res.send(bins);
+    });
+  },
   renderHistory: function (req, res, next, bins) {
     var accepts = req.header('Accept', '');
 
@@ -1154,7 +1188,7 @@ module.exports = Observable.extend({
         });
 
 
-    this.formatHistory(bins, format, function (err, history) {
+    this.formatHistory(bins, function (err, history) {
       if (acceptsJSON) {
         res.send(history);
       } else {
@@ -1478,14 +1512,33 @@ module.exports = Observable.extend({
         urls = {},
         orderedBins, loopOrder, i, length;
 
-    if (typeof format === 'function') {
+    if (fn === undefined) {
       fn = format;
-      format = 'html';
+      format = function (bin, map) {
+        var settings = bin.settings || {};
+        var desc = settings.desc || settings.title;
+
+        return {
+          code: bin.url,
+          revision: bin.revision,
+          summary: desc || bin.summary || utils.titleForBin(bin),
+          archive: bin.archive,
+          url: helpers.urlForBin(bin),
+          edit_url: helpers.editUrlForBin(bin),
+          last_updated: bin.last_updated.toISOString(),
+          pretty_last_updated: utils.since(bin.last_updated),
+          is_first: !map[bin.url].length
+        }
+      };
     }
 
     bins.forEach(function (bin) {
       if (bin.active === 'n' || bin.archive === -1) {
         return;
+      }
+
+      if (!bin.last_updated && bin.created) {
+        bin.last_updated = bin.created;
       }
 
       var time = new Date(bin.last_updated).getTime();
@@ -1535,20 +1588,7 @@ module.exports = Observable.extend({
         data.push(revisions);
       }
 
-      var settings = bin.settings || {};
-      var desc = settings.desc || settings.title;
-
-      revisions.push({
-        code: bin.url,
-        revision: bin.revision,
-        summary: desc || bin.summary || utils.titleForBin(bin),
-        archive: bin.archive,
-        url: helpers.urlForBin(bin),
-        edit_url: helpers.editUrlForBin(bin),
-        last_updated: bin.last_updated.toISOString(),
-        pretty_last_updated: utils.since(bin.last_updated),
-        is_first: !map[bin.url].length
-      });
+      revisions.push(format(bin, map));
     });
 
     fn(null, data);

--- a/lib/models/user.js
+++ b/lib/models/user.js
@@ -156,6 +156,15 @@ module.exports = Observable.extend({
     };
     this.store.getBinsByUser(id, fn);
   },
+  getUserListing: function (id, fn) { // aka getDetailedBins (sandbox.settings for title + desc)
+    var timer = metrics.createTimer(metricPrefix + 'getUserListing');
+    var original = fn;
+    fn = function () {
+      timer.stop();
+      original.apply(this, [].slice.call(arguments));
+    };
+    this.store.getUserListing(id, fn);
+  },
   isOwnerOf: function (username, bin, fn) {
     var params = {
       name: username,

--- a/lib/store.js
+++ b/lib/store.js
@@ -63,6 +63,7 @@ var methods = [
   'getCustomerByStripeId',
   'getCustomerByUser',
   'getBinMetadata',
+  'getUserListing',
   'setBinVisibility',
   'updateBinData',
   'updateOwnersData',

--- a/public/js/chrome/save.js
+++ b/public/js/chrome/save.js
@@ -146,7 +146,6 @@ var lastHTML = null;
 function updateDocMeta(event, data) {
   if (data) {
     if (data.panelId !== 'html') {
-      console.log('bail');
       return; // ignore non-html updates
     }
   }
@@ -173,8 +172,6 @@ function updateDocMeta(event, data) {
         document.title = jsbin.name;
       }
     }
-
-    console.log(jsbin.state.title, jsbin.state.description);
   }
 }
 

--- a/views/index.html
+++ b/views/index.html
@@ -159,7 +159,7 @@ if(top != self) {
                   </div>
                 </div>
                 {{else}}
-                <div data-desc="This bin's full output without the JS Bin editor">
+                <div data-desc="This bin's full output without the JS Bin editor" class="ui-full-output">
                   <strong><a class="link" data-path="/" target="_blank" href="{{root}}{{code_id_path}}">Output only (with live reload)</a></strong><br><input data-path="/" class="link" id="livepreview" value="{{root}}{{code_id_path}}/" type="text">
                 </div>
                 <hr>
@@ -173,13 +173,13 @@ if(top != self) {
                     <li><label><input type="checkbox" data-panel="live">Output</label></li>
                   </ul>
                 </div>
-                <div data-desc="The url to this bin with the JS Bin editor">
+                <div data-desc="The url to this bin with the JS Bin editor" class="ui-binurl">
                   <a class="link heading" data-path="/edit" target="_blank" href="{{root}}{{code_id_path}}/edit">Link</a><br><input data-path="/edit" class="link" value="{{root}}{{code_id_path}}/edit" type="text">
                 </div>
-                <div data-desc="Embed this bin with the live output on your site">
+                <div data-desc="Embed this bin with the live output on your site" class="ui-embed">
                   <span class="heading">Embed</span><br><textarea id="embedfield" data-path="/embed" class="link">&lt;a class=&quot;jsbin-embed&quot; href=&quot;{{root}}{{code_id_path}}/embed?live&quot;&gt;JS Bin demo&lt;/a&gt;&lt;script src=&quot;{{static}}/js/embed.js&quot;&gt;&lt;/script&gt;</textarea>
                 </div>
-                <div data-desc="Training/Viewer mode: codecast your bin to any viewers" class="disabled">
+                <div data-desc="Training/Viewer mode: codecast your bin to any viewers" class="disabled ui-codecast">
                   <a class="link heading" target="_blank" data-path="/watch" href="{{root}}{{code_id_path}}/watch">Codecast</a><br><input data-path="/watch" class="link" value="{{root}}{{code_id_path}}/watch" type="text">
                 </div>
                 <div data-desc="Disallow further changes to this specific revision" data-shortcut="ctrl+s" class="lockoption" id="enablelock"><div title="Locks the bin's content so no more changes will be made this URL, and typing will create a new bin as if you 'created milestone'" class="icon-unlocked lockrevision"><span>Click to lock and prevent further changes</span></div>


### PR DESCRIPTION
- [x] Ready to merge

PR to change the user listings so we get better details about the actual bin content.

- [x] API sends title + desc
- [x] Save title + desc when user is editing

## Detail

- [x] When user saves - if it's the first time, try to read title + desc (from HTML) and add these to settings, otherwise use default values.
- [x] When an HTML panel is saved, re-parse the title + desc

## Issues

- What if there's no HTML?
- What if the HTML is the boilerplate (`title=JS Bin`) and we never see the HTML again? It'll be "JS Bin" repeated over and over...