### PR TITLE
Get instead of set url prefix

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -133,7 +133,7 @@ app.set('view engine', 'html');
 app.set('views', path.join(app.get('root'), 'views'));
 app.set('url prefix', options.url.prefix);
 app.set('url ssl', options.url.ssl);
-app.set('url full', 'http://' + app.get('url host') + app.set('url prefix'));
+app.set('url full', 'http://' + app.get('url host') + app.get('url prefix'));
 app.set('basepath', app.get('url prefix'));
 app.set('is_production', app.get('env') === app.PRODUCTION);
 


### PR DESCRIPTION
Using `set` is not breaking things here though, since it returns the value when a second parameter isn't given.