### PR TITLE
Update Bootstrap *latest* library to version 3.3.4

### DIFF
--- a/public/js/editors/libraries.js
+++ b/public/js/editors/libraries.js
@@ -108,8 +108,8 @@ var libraries = [
   {
     'url': [
       '//code.jquery.com/jquery.min.js',
-      '//maxcdn.bootstrapcdn.com/bootstrap/3.3.2/css/bootstrap.min.css',
-      '//maxcdn.bootstrapcdn.com/bootstrap/3.3.2/js/bootstrap.min.js'
+      '//maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css',
+      '//maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js'
     ],
     'label': 'Bootstrap Latest',
     'group': 'Bootstrap'


### PR DESCRIPTION
This PR updates urls of Bootstrap CDNs to latest 3.3.4 version urls.
Please see - to see why they skipped 3.3.3 version:
http://blog.getbootstrap.com/2015/03/16/bootstrap-3-3-4-released/

Tested locally with:
http://jsbin.com/nucada/6/edit

Thanks!