### PR TITLE
Add Ember Data v1.0.0-beta.16 to libraries

### DIFF
--- a/public/js/editors/libraries.js
+++ b/public/js/editors/libraries.js
@@ -390,7 +390,13 @@ var libraries = [
       '//builds.handlebarsjs.com.s3.amazonaws.com/handlebars-v2.0.0.js',
       '//builds.emberjs.com/tags/v1.9.0/ember.js'
     ],
-    'label': 'Ember.js 1.9.0'
+    'label': 'Ember.js 1.9.0',
+    'group': 'Ember'
+  },
+  {
+    'url': '//builds.emberjs.com/tags/v1.0.0-beta.16/ember-data.js',
+    'label': 'Ember Data 1.0.0-beta.16',
+    'group': 'Ember'
   },
   {
     'url': 'https://cdnjs.cloudflare.com/ajax/libs/normalize/3.0.2/normalize.min.css',


### PR DESCRIPTION
- Adds ember data v1.0.0-beta.16 to the list of libraries
- Adds an "Ember" group that contains ember and ember data

Ember data and its [Fixture Adapter](http://emberjs.com/api/data/classes/DS.FixtureAdapter.html) are really useful when making jsbins. It would be nice to not have to go find a link to the build and add the script tag manually.