### PR TITLE
A new default for ember.jsbin

### DIFF
--- a/public/custom/emberjs/default.html
+++ b/public/custom/emberjs/default.html
@@ -5,8 +5,10 @@
   <title>Ember Starter Kit</title>
   <link rel="stylesheet" href="http://cdnjs.cloudflare.com/ajax/libs/normalize/3.0.1/normalize.css">
   <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
-  <script src="http://builds.emberjs.com/tags/v1.10.0/ember-template-compiler.js"></script>
-  <script src="http://builds.emberjs.com/tags/v1.10.0/ember.debug.js"></script>
+  <script src="http://builds.emberjs.com/tags/v1.11.0/ember-template-compiler.js"></script>
+  <script src="http://builds.emberjs.com/tags/v1.11.0/ember.debug.js"></script>
+  <script src="//cdnjs.cloudflare.com/ajax/libs/ember-data.js/1.0.0-beta.16.1/ember-data.min.js"></script>
+  <script src="//cdnjs.cloudflare.com/ajax/libs/jquery-mockjax/1.5.3/jquery.mockjax.js"></script>
 </head>
 <body>
 
@@ -18,9 +20,9 @@
 
   <script type="text/x-handlebars" data-template-name="index">
     <ul>
-    {{#each item in model}}
-      <li>{{item}}</li>
-    {{/each}}
+      {{#each color in model}}
+        <li>{{color.name}}</li>
+      {{/each}}
     </ul>
   </script>
 

--- a/public/custom/emberjs/default.html
+++ b/public/custom/emberjs/default.html
@@ -5,8 +5,8 @@
   <title>Ember Starter Kit</title>
   <link rel="stylesheet" href="http://cdnjs.cloudflare.com/ajax/libs/normalize/3.0.1/normalize.css">
   <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
-  <script src="http://builds.emberjs.com/tags/v1.11.0/ember-template-compiler.js"></script>
-  <script src="http://builds.emberjs.com/tags/v1.11.0/ember.debug.js"></script>
+  <script src="http://builds.emberjs.com/tags/v1.11.1/ember-template-compiler.js"></script>
+  <script src="http://builds.emberjs.com/tags/v1.11.1/ember.debug.js"></script>
   <script src="//cdnjs.cloudflare.com/ajax/libs/ember-data.js/1.0.0-beta.16.1/ember-data.min.js"></script>
   <script src="//cdnjs.cloudflare.com/ajax/libs/jquery-mockjax/1.5.3/jquery.mockjax.js"></script>
 </head>
@@ -20,7 +20,7 @@
 
   <script type="text/x-handlebars" data-template-name="index">
     <ul>
-      {{#each color in model}}
+      {{#each model as |color|}}
         <li>{{color.name}}</li>
       {{/each}}
     </ul>

--- a/public/custom/emberjs/default.js
+++ b/public/custom/emberjs/default.js
@@ -6,6 +6,31 @@ App.Router.map(function() {
 
 App.IndexRoute = Ember.Route.extend({
   model: function() {
-    return ['red', 'yellow', 'blue'];
+    return this.store.find('color');
+  }  
+});
+
+App.ColorModel = DS.Model.extend({
+  name: DS.attr('string')
+});
+
+$.mockjax({
+  url: "/colors",
+  type: "GET",
+  status: 200,
+  statusText: "OK",
+  responseText: {
+    colors: [{
+      id: 1,
+      name: "Red"
+    },
+    {
+      id: 2,
+      name: "Green"
+    },
+    {
+      id: 3,
+      name: "Blue"
+    }]
   }
 });


### PR DESCRIPTION
After many repetitions of setting up my own jsbin to recreate issues.  I thought that perhaps having a default ember jsbin that included ember-data and a set of mockjax data, would help other new users set up their own examples.

I have found that many newer users (myself included) were hesitant to recreate their issues on jsbin, because it involved setting up their ember-data models and their ajax assets. This PR simply provides a few more basic setup that the user may need.

this bin has the latest ember 1.11 and ember-data beta16.1

(also open to the possibility of a "ember-data.jsbin")

Thoughts?