### PR TITLE
Update ember.js to v1.11.3

### DIFF
--- a/public/custom/emberjs/default.html
+++ b/public/custom/emberjs/default.html
@@ -5,8 +5,8 @@
   <title>Ember Starter Kit</title>
   <link rel="stylesheet" href="http://cdnjs.cloudflare.com/ajax/libs/normalize/3.0.1/normalize.css">
   <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
-  <script src="http://builds.emberjs.com/tags/v1.11.0/ember-template-compiler.js"></script>
-  <script src="http://builds.emberjs.com/tags/v1.11.0/ember.debug.js"></script>
+  <script src="http://builds.emberjs.com/tags/v1.11.3/ember-template-compiler.js"></script>
+  <script src="http://builds.emberjs.com/tags/v1.11.3/ember.debug.js"></script>
 </head>
 <body>
 
@@ -18,7 +18,7 @@
 
   <script type="text/x-handlebars" data-template-name="index">
     <ul>
-    {{#each item in model}}
+    {{#each model as |item|}}
       <li>{{item}}</li>
     {{/each}}
     </ul>

--- a/public/js/editors/libraries.js
+++ b/public/js/editors/libraries.js
@@ -394,10 +394,10 @@ var libraries = [
   {
     'url': [
       '//code.jquery.com/jquery-1.11.1.min.js',
-      '//builds.emberjs.com/tags/v1.11.1/ember-template-compiler.js',
-      '//builds.emberjs.com/tags/v1.11.1/ember.debug.js'
+      '//builds.emberjs.com/tags/v1.11.3/ember-template-compiler.js',
+      '//builds.emberjs.com/tags/v1.11.3/ember.debug.js'
     ],
-    'label': 'Ember.js 1.11.1',
+    'label': 'Ember.js 1.11.3',
     'group': 'Ember'
   },
   {


### PR DESCRIPTION
Thanks for merging the other ones. Sadly they're already out of date :panda_face: 

This updates the ember version to 1.11.3 (latest) and replaces deprecated `{{#each ... in ...}}` syntax in the default ember template.