### PR TITLE
Support security.preview config

### DIFF
--- a/config.default.json
+++ b/config.default.json
@@ -139,6 +139,7 @@
     "nudge",
     "null",
     "open",
+    "output",
     "oauth",
     "post",
     "pro",

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -101,6 +101,7 @@ module.exports = function (app) {
     // 2. if not, then check if the req.headers.host matches security.preview
     // 3. if not, redirect
     var metadata = undefsafe(req, 'bin.metadata');
+    var output = undefsafe(config, 'security.preview');
     var settings = {};
     var ssl = false;
     var url;
@@ -110,13 +111,32 @@ module.exports = function (app) {
       return next();
     }
 
-    if (settings) {
-      try {
-        // TODO why on earth am I expecting JSON???
-        settings = typeof metadata.settings === 'string' ? JSON.parse(metadata.settings) : metadata.settings;
-        ssl = features('sslForAll', { session: { user: { name: metadata.name, pro: metadata.pro, settings: { ssl: settings.ssl }}}});
-      } catch (e) {}
+    // redirect to output url (to prevent cross origin attacks)
+    if (output && req.headers.host.indexOf(config.url.host) === 0) {
+      return res.redirect((req.secure ? 'https://' : 'http://') + output + req.url);
     }
+
+    try {
+      // TODO why on earth am I expecting JSON???
+      settings = typeof metadata.settings === 'string' ? JSON.parse(metadata.settings) : metadata.settings;
+
+      if (metadata.pro) {
+        // check the leading cname
+      }
+
+      // fake the request object with a session
+      ssl = features('sslForAll', {
+        session: {
+          user: {
+            name: metadata.name,
+            pro: metadata.pro,
+            settings: {
+              ssl: settings.ssl,
+            },
+          },
+        },
+      });
+    } catch (e) {}
 
     if (features('sslForAll', req)) {
       return next();

--- a/public/js/chrome/share.js
+++ b/public/js/chrome/share.js
@@ -125,7 +125,7 @@
 
   function update() {
     var data = formData(form);
-    var url = jsbin.getURL();
+    var url = jsbin.getURL({ root: jsbin.shareRoot });
 
     if (data.state === 'snapshot' && jsbin.state.latest) {
       url += '/' + selectedSnapshot;

--- a/public/js/jsbin.js
+++ b/public/js/jsbin.js
@@ -235,7 +235,8 @@ jsbin.getURL = function (options) {
   if (!options) { options = {}; }
 
   var withoutRoot = options.withoutRoot;
-  var url = withoutRoot ? '' : jsbin.root;
+  var root = options.root || jsbin.root;
+  var url = withoutRoot ? '' : root;
   var state = jsbin.state;
 
   if (state.code) {


### PR DESCRIPTION
Allows output urls to be output.jsbin.com to harden security around origin attacks. 

Yay. :tada: :man:  :gun: (me)