### PR TITLE
Update Zurb Foundation to 5.5.2 version

### DIFF
--- a/public/js/editors/libraries.js
+++ b/public/js/editors/libraries.js
@@ -422,12 +422,13 @@ var libraries = [
   },
   {
     'url': [
-      '//cdnjs.cloudflare.com/ajax/libs/foundation/5.0.3/css/normalize.min.css',
-      '//cdnjs.cloudflare.com/ajax/libs/foundation/5.0.3/css/foundation.min.css',
-      '//cdnjs.cloudflare.com/ajax/libs/foundation/5.0.3/js/vendor/jquery.min.js',
-      '//cdnjs.cloudflare.com/ajax/libs/foundation/5.0.3/js/foundation.min.js'
+      '//cdnjs.cloudflare.com/ajax/libs/foundation/5.5.2/css/normalize.min.css',
+      '//cdnjs.cloudflare.com/ajax/libs/foundation/5.5.2/css/foundation.min.css',
+      '//cdnjs.cloudflare.com/ajax/libs/foundation/5.5.2/js/vendor/modernizr.js',
+      '//cdnjs.cloudflare.com/ajax/libs/foundation/5.5.2/js/vendor/jquery.js',
+      '//cdnjs.cloudflare.com/ajax/libs/foundation/5.5.2/js/foundation.min.js'
     ],
-    'label': 'Foundation 5.0.3'
+    'label': 'Foundation 5.5.2'
   },
   {
     'url': '//cdnjs.cloudflare.com/ajax/libs/handlebars.js/1.0.0/handlebars.js',


### PR DESCRIPTION
This PR:
- updates Foundation libraries to 5.5.2 version
- adds those libraries that are used in Foundation
*Complete* example download, so user can start with the same
example markup html as in Zurb's documentation

For example one should be able to use generated template to render exactly the same content as provided by Zurb in *Complete* download file:
http://foundation.zurb.com/develop/download.html

http://jsbin.com/debehe/2/edit?html,js,output

Thanks!
