### PR TITLE
add core-js shim to libraries

### DIFF
--- a/public/js/editors/libraries.js
+++ b/public/js/editors/libraries.js
@@ -324,6 +324,16 @@ var libraries = [
     'group': 'React'
   },
   {
+    'url': 'https://cdn.rawgit.com/zloirock/core-js/master/client/shim.min.js',
+    'label': 'core-js',
+    'group': 'shims'
+  },
+  {
+    'url': 'https://cdnjs.cloudflare.com/ajax/libs/es5-shim/2.0.8/es5-shim.min.js',
+    'label': 'ES5 shim 2.0.8',
+    'group': 'shims'
+  },
+  {
     'url': 'http://vuejs.org/js/vue.js',
     'label': 'Vue.js',
   },
@@ -418,10 +428,6 @@ var libraries = [
   {
     'url': 'https://cdnjs.cloudflare.com/ajax/libs/normalize/3.0.2/normalize.min.css',
     'label': 'Normalize.css 3.0.2'
-  },
-  {
-    'url': 'https://cdnjs.cloudflare.com/ajax/libs/es5-shim/2.0.8/es5-shim.min.js',
-    'label': 'ES5 shim 2.0.8'
   },
   {
     'url': [


### PR DESCRIPTION
[In my other pull request](https://github.com/jsbin/jsbin/pull/2368#issuecomment-107027702) I tried to add the ES6/7 shims with Babel, but I think the better way is just adding the [`core-js`](https://github.com/zloirock/core-js) library to the libraries dropdown.

This pull request adds `core-js` to the list of libraries and creates a group called `shims`, which also includes the ES5 shim.

![core-js example](https://cloud.githubusercontent.com/assets/1227441/7936477/9935536e-0939-11e5-974f-8c245075bbcb.png)
