### PR TITLE
Adds Popcorn.js 1.5.6 to libraries

### DIFF
--- a/public/js/editors/libraries.js
+++ b/public/js/editors/libraries.js
@@ -616,6 +616,16 @@ var libraries = [
     'label': 'rx.dom',
     'group': 'RxJS'
   },
+  {
+    'url': 'http://cdn.popcornjs.org/code/dist/popcorn.min.js',
+    'label': 'Popcorn.js 1.5.6 (Core)',
+    'group': 'Popcorn.js'
+  },
+  {
+    'url': 'http://cdn.popcornjs.org/code/dist/popcorn-complete.min.js',
+    'label': 'Popcorn.js 1.5.6 (Core + Extensions)',
+    'group': 'Popcorn.js'
+  },
 ];
 
 window.libraries = libraries; // expose a command line API


### PR DESCRIPTION
- Popcorn.js 1.5.6 (Core)
- Popcorn.js 1.5.6 (Core + Extensions)