### PR TITLE
Bump ember and ember-data versions

### DIFF
--- a/public/custom/emberjs/default.html
+++ b/public/custom/emberjs/default.html
@@ -5,8 +5,8 @@
   <title>Ember Starter Kit</title>
   <link rel="stylesheet" href="http://cdnjs.cloudflare.com/ajax/libs/normalize/3.0.1/normalize.css">
   <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
-  <script src="http://builds.emberjs.com/tags/v1.12.0/ember-template-compiler.js"></script>
-  <script src="http://builds.emberjs.com/tags/v1.12.0/ember.debug.js"></script>
+  <script src="http://builds.emberjs.com/tags/v1.12.1/ember-template-compiler.js"></script>
+  <script src="http://builds.emberjs.com/tags/v1.12.1/ember.debug.js"></script>
 </head>
 <body>
 

--- a/public/js/editors/libraries.js
+++ b/public/js/editors/libraries.js
@@ -414,15 +414,15 @@ var libraries = [
   {
     'url': [
       'https://code.jquery.com/jquery-1.11.1.min.js',
-      '//builds.emberjs.com/tags/v1.11.3/ember-template-compiler.js',
-      '//builds.emberjs.com/tags/v1.11.3/ember.debug.js'
+      '//builds.emberjs.com/tags/v1.12.1/ember-template-compiler.js',
+      '//builds.emberjs.com/tags/v1.12.1/ember.debug.js'
     ],
-    'label': 'Ember.js 1.11.3',
+    'label': 'Ember.js 1.12.1',
     'group': 'Ember'
   },
   {
-    'url': '//builds.emberjs.com/tags/v1.0.0-beta.16.1/ember-data.js',
-    'label': 'Ember Data 1.0.0-beta.16.1',
+    'url': '//builds.emberjs.com/tags/v1.0.0-beta.19/ember-data.js',
+    'label': 'Ember Data 1.0.0-beta.19',
     'group': 'Ember'
   },
   {


### PR DESCRIPTION
- Bumps ember version to 1.12.1 (current release)
- Bumps ember data to 1.0.0-beta.19