### PR TITLE
fix: support posting again

### DIFF
--- a/lib/fat-flash.js
+++ b/lib/fat-flash.js
@@ -1,0 +1,40 @@
+'use strict';
+var uuid = require('uuid');
+var debug = require('debug')('jsbin:flash');
+var cache = {};
+
+var flash = module.exports = {
+  get: function (key) {
+    var item = cache[key];
+    debug('get: %s - result?', key, !!item);
+    flash.clear(key);
+    return item.value || null;
+  },
+  set: function (value) {
+    var key = uuid.v4();
+
+    debug('set id: %s - value?', key, !!value);
+
+    var timer = setTimeout(function () {
+      debug('timeout on %s', key);
+      flash.clear(key);
+    }, 1000 * 5);
+
+    cache[key] = {
+      value: value,
+      timer: timer,
+    };
+
+    return key;
+  },
+  clear: function (key) {
+    if (!key) {
+      Object.keys(cache).forEach(flash.clear);
+      cache = {};
+    } else {
+      debug('clearing %s', key);
+      clearTimeout(cache[key].timer);
+      delete cache[key];
+    }
+  },
+};

--- a/lib/handlers/bin.js
+++ b/lib/handlers/bin.js
@@ -15,7 +15,8 @@ var async      = require('asyncjs'),
     config     = require('../config'),
     welcomePanel = require('../welcome-panel'),
     binToFile  = require('bin-to-file'),
-    Observable = utils.Observable;
+    Observable = utils.Observable,
+    flash      = require('../fat-flash');
 
 module.exports = Observable.extend({
   constructor: function BinHandler(sandbox) {
@@ -83,6 +84,8 @@ module.exports = Observable.extend({
     }
 
     data.post = true;
+    var id = flash.set(data);
+    req.flash('postedBin', id);
 
     this.render(req, res, data);
   },

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -13,6 +13,7 @@ var express = require('express'),
     processors = require('./processors'),
     middleware = require('./middleware'),
     metrics = require('./metrics'),
+    flash = require('./fat-flash'),
     scripts = require('../scripts.json'),
     Promise = require('rsvp').Promise, // jshint ignore:line
     undefsafe = require('undefsafe'),
@@ -775,8 +776,13 @@ module.exports = function (app) {
       req.live = true;
     }
 
+    var postedBinId = req.flash('postedBin');
+
     if (req.params.bin) {
       return binHandler.loadBin(req, res, next);
+    } else if (postedBinId) {
+      req.bin = flash.get(postedBinId);
+      next();
     } else {
       binHandler.loadFiles(binHandler.defaultFiles(), function (err, results) {
         if (!err) {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "bin-to-file": "0.0.5",
     "clone": "~0.1.18",
     "commander": "1.0.0",
+    "debug": "^2.2.0",
     "dropbox": "~0.10.2",
     "express": "3.0.x",
     "express-cookie-blacklist": "~2.0.0",
@@ -63,6 +64,7 @@
     "stylus": "^0.47.1",
     "undefsafe": "0.0.3",
     "underscore": "~1.4.4",
+    "uuid": "^2.0.1",
     "validate-vat": "~0.3.1",
     "validator": "^3.16.1"
   },


### PR DESCRIPTION
Since we moved to a separate loader for the bin content, it meant that the 2nd http request (for start.js) didn't know anything about the POSTed values sent to the editor page. I tried to store it originally on the `req.flash` but the example pages from the FT were great because they were larger than the cookie could handle (and thus were chomped and discarded).

It took me a looooong time to work it out, but actually a simple memory store fixes the issue. Similar to a flash that's stored on the cookie, but this is a time sensitive flash that's kept in memory, and removed as soon as it's retrieved (but also removed after a 5 second timeout). Since it's an edge case of JS Bin, I'm happy that it's in memory (though I will have to keep an eye on it too).

Fixes #2425 