### PR TITLE
Add engine advisory field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,10 +83,6 @@
   "optionalDependencies": {
     "zmq": "~2.6.0"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "http://rem.mit-license.org"
-    }
-  ]
+  "engines": { "node": ">=0.10.* <0.12" },
+  "license": "MIT"
 }


### PR DESCRIPTION
This should be helpful in heading off issues such as #2370 and #2358 and prevent people from heading down the wrong path in troubleshooting. Also corrected the `license` option while I was there: `licenses` was deprecated a while back apparently and without `license` npm logs warnings about a lack of license.