### PR TITLE
fix: embed replaces iframe to avoid history push

### DIFF
--- a/public/js/embed.js
+++ b/public/js/embed.js
@@ -217,11 +217,13 @@
   }
 
   function loadRealEmbed(iframe) {
-    var url = iframe.getAttribute('data-url');
+    var clone = iframe.cloneNode();
+    var url = clone.getAttribute('data-url');
 
-    iframe.src = url.split('&')[0];
-    iframe._src = url.split('&')[0]; // support for google slide embed
-    hookMessaging(iframe);
+    clone.src = url.split('&')[0];
+    clone._src = url.split('&')[0]; // support for google slide embed
+    iframe.parentNode.replaceChild(clone, iframe);
+    hookMessaging(clone);
   }
 
   function embed(link) {


### PR DESCRIPTION
Instead of setting the .src on the iframe causing the url to push onto the history stack.

Fixes #2464