### PR TITLE
fix: generate longer IDs when using sqlite

### DIFF
--- a/lib/db/sqlite.js
+++ b/lib/db/sqlite.js
@@ -169,16 +169,15 @@ module.exports = utils.inherit(Object, {
     this.connection.run(templates.getOwnersBlock, [start, size], fn);
   },
   generateBinId: function (length, attempts, fn) {
-    var id = utils.shortcode(), mysql = this;
-
     attempts = attempts || 1;
+    var id = utils.shortcode( attempts + 2 ), sqlite = this;
+
     if (attempts <= 10) {
       this.connection.get(templates.binExists, [id], function (err, result) {
         if (err) {
           fn(err);
         } else if (result) {
-          attempts += 1;
-          mysql.generateBinId(length, attempts, fn);
+          sqlite.generateBinId(length, attempts + 1, fn);
         } else {
           fn(null, id);
         }


### PR DESCRIPTION
The sqlite ID generation code was intending to recursively try longer
IDs until one was found without collision, however the recursive call
didn't actually try longer IDs, and just made 10 attempts at finding a
3 character ID (the default).

This was causing my self-hosted instance of jsbin to fail to create IDs longer than 3 characters, and as we created more and more bins the chance of collision was very high and saving was very difficult.