### PR TITLE
Add jQuery & jQuery Compat 3.0.0-alpha1

### DIFF
--- a/public/js/editors/libraries.js
+++ b/public/js/editors/libraries.js
@@ -5,6 +5,11 @@ var libraries = [
     'group': 'jQuery'
   },
   {
+    'url': 'https://code.jquery.com/jquery-3.0.0-alpha1.min.js',
+    'label': 'jQuery 3.0.0-alpha1',
+    'group': 'jQuery'
+  },
+  {
     'url': 'https://code.jquery.com/jquery-2.1.1.min.js',
     'label': 'jQuery 2.1.1',
     'group': 'jQuery'
@@ -12,6 +17,11 @@ var libraries = [
   {
     'url': 'https://code.jquery.com/jquery-compat-git.js',
     'label': 'jQuery Compat WIP (via git)',
+    'group': 'jQuery'
+  },
+  {
+    'url': 'https://code.jquery.com/jquery-compat-3.0.0-alpha1.min.js',
+    'label': 'jQuery Compat 3.0.0-alpha1',
     'group': 'jQuery'
   },
   {


### PR DESCRIPTION
I'll be submitting PRs changing this to further 3.0.0 alphas/betas so that people can test the latest released preview of the upcoming jQueries 3.0.0.

BTW, I've noticed that some of the links direct to minified files and some to full ones (like jQuery UI). Why is that? Wouldn't it be better if all links were non-minified? It's just for testing anyway.