### PR TITLE
Bump ember-data version to 1.13.6

### DIFF
--- a/public/js/editors/libraries.js
+++ b/public/js/editors/libraries.js
@@ -453,8 +453,8 @@ var libraries = [
     'group': 'Ember'
   },
   {
-    'url': '//builds.emberjs.com/tags/v1.13.5/ember-data.js',
-    'label': 'Ember Data 1.13.5',
+    'url': '//builds.emberjs.com/tags/v1.13.6/ember-data.js',
+    'label': 'Ember Data 1.13.6',
     'group': 'Ember'
   },
   {


### PR DESCRIPTION
Bumps ember-data version to 1.13.6 ([current release](http://emberjs.com/builds/#/release))