### PR TITLE
Adding keywords to bins and filter in history screen

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -3788,6 +3788,28 @@ left: 50%;
   margin: 10px 0;
 }
 
+#history .filter {
+  width: 75%;
+  margin-bottom: 2px;
+  padding-bottom: 2px;
+  max-width: 1280px;
+  margin: 0 auto;
+}
+
+#history .filter input[type="text"] {
+ width: 50%; 
+ font-size: 14px;
+}
+
+/* Bin tags used in the history view */
+#history .tags {
+  font-size: 12px;
+}
+
+#history .tags a {
+  color: rgb(161, 216, 253);
+}
+
 #history iframe-dead {
   -webkit-transform: scale(0.8);
      -moz-transform: scale(0.8);

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -3794,6 +3794,11 @@ left: 50%;
   padding-bottom: 2px;
   max-width: 1280px;
   margin: 0 auto;
+  font-family: "Helvetica Neue", Helvetica, Arial;
+}
+
+#history .filter label {
+  font-size: 14px;
 }
 
 #history .filter input[type="text"] {
@@ -3801,12 +3806,12 @@ left: 50%;
  font-size: 14px;
 }
 
-/* Bin tags used in the history view */
-#history .tags {
+/* Bin keywords used in the history view */
+#history .keywords {
   font-size: 12px;
 }
 
-#history .tags a {
+#history .keywords a {
   color: rgb(161, 216, 253);
 }
 

--- a/public/js/chrome/navigation.js
+++ b/public/js/chrome/navigation.js
@@ -466,6 +466,65 @@ $('#addmeta').click(function () {
   return false;
 });
 
+
+
+var kre = {
+  head: /<head(.*)\n/i,
+  meta: /<meta name="keywords".*?>/i,
+  metaContent: /content=".*?"/i
+};
+
+var keywords = '<meta name="keywords" content="[add your comma separated keywords]">\n';
+
+$('#addkeywords').click(function() {
+  // if not - insert
+  // <meta name="description" content="" />
+  // if meta description is in the HTML, highlight it
+  var editor = jsbin.panels.panels.html,
+      cm = editor.editor,
+      html = editor.getCode();
+
+  if (!editor.visible) {
+    editor.show();
+  }
+
+  if (!kre.meta.test(html)) {
+    if (kre.head.test(html)) {
+      html = html.replace(kre.head, '<head$1\n' + keywords);
+    } else {
+      // slap in the top
+      html = keywords + html;
+    }
+  }
+
+  editor.setCode(html);
+
+  // now select the text
+  // editor.editor is the CM object...yeah, sorry about that...
+  var cursor = cm.getSearchCursor(kre.meta);
+  cursor.findNext();
+
+  var contentCursor = cm.getSearchCursor(kre.metaContent);
+  contentCursor.findNext();
+
+  var from = { line: cursor.pos.from.line, ch: cursor.pos.from.ch + '<meta name="keywords" content="'.length },
+      to = { line: contentCursor.pos.to.line, ch: contentCursor.pos.to.ch - 1 };
+
+  cm.setCursor(from);
+  cm.setSelection(from, to);
+  cm.on('cursoractivity', function () {
+    cm.on('cursoractivity', null);
+    mark.clear();
+  });
+
+  var mark = cm.markText(from, to, { className: 'highlight' });
+
+  cm.focus();
+
+  return false;
+});
+
+
 $('a.publish-to-vanity').on('click', function (event) {
   event.preventDefault();
   analytics.publishVanity();

--- a/views/history.html
+++ b/views/history.html
@@ -7,8 +7,8 @@
       </div>
     </div>
     <div class="filter">
-      <input type="text" placeholder="filter on tags" />
-      <label>select tag
+      <input type="text" placeholder="filter on keywords" />
+      <label>or select a keyword
         <select>
           <option selected>--select--</option>
           <option>Angular</option>
@@ -39,7 +39,7 @@
         <td class="title">
           <a href="{{edit_url}}">{{summary}}</a>
         </td>
-        <td class="tags">
+        <td class="keywords">
           <a href="#">jQuery</a>,<a href="#">Angular</a>,<a href="#">scss</a>, <a href="#">directives</a>, <a href="#">gaming</a>
         </td>
         <td class="action">

--- a/views/history.html
+++ b/views/history.html
@@ -1,8 +1,22 @@
 <div id="history">
-  <div class="header">
-    <h2>Open previously saved <em>bins</em>{{by_user}} or <a href="#" data-toggle="history">continue with current one</a>:</h2>
-    <div class="menu">
-      <input type="checkbox" name="toggle_archive" id="toggleArchive" class="toggle_archive"> <label for="toggleArchive">Archive view</label>
+  <div class="control">
+    <div class="header">
+      <h2>Open previously saved <em>bins</em>{{by_user}} or <a href="#" data-toggle="history">continue with current one</a>:</h2>
+      <div class="menu">
+        <input type="checkbox" name="toggle_archive" id="toggleArchive" class="toggle_archive"> <label for="toggleArchive">Archive view</label>
+      </div>
+    </div>
+    <div class="filter">
+      <input type="text" placeholder="filter on tags" />
+      <label>select tag
+        <select>
+          <option selected>--select--</option>
+          <option>Angular</option>
+          <option>jQuery</option>
+          <option>directives</option>
+          <option>gaming</option>
+        </select>
+      </label>
     </div>
   </div>
   <table>
@@ -22,13 +36,16 @@
         <td class="last_updated">
           <a pubdate="{{last_updated}}" href="{{edit_url}}">{{pretty_last_updated}}</a>
         </td>
-        <td class="action">
-          <!-- <a href="{{url}}/edit" class="edit"><span>Edit</span></a> -->
-          <a href="{{url}}/archive" class="archive"><span>Archive</span></a>
-          <a href="{{url}}/unarchive" class="unarchive"><span>Un-archive</span></a>
-        </td>
         <td class="title">
           <a href="{{edit_url}}">{{summary}}</a>
+        </td>
+        <td class="tags">
+          <a href="#">jQuery</a>,<a href="#">Angular</a>,<a href="#">scss</a>, <a href="#">directives</a>, <a href="#">gaming</a>
+        </td>
+        <td class="action">
+          <!-- <a href="{{url}}/edit" class="edit"><span>Edit</span></a> -->
+          <a href="{{url}}/archive" class="archive" title="Archive this bin"><span>Archive</span></a>
+          <a href="{{url}}/unarchive" class="unarchive" title="Unarchive this bin"><span>Un-archive</span></a>
         </td>
       </tr>
       {{/.}}

--- a/views/partials/control_navigation.html
+++ b/views/partials/control_navigation.html
@@ -32,6 +32,8 @@
               {{/if}}
               <hr data-desc="">
               <a id="addmeta" data-desc="Insert a description shown in My Bins" title="Add meta data to bin" class="button group" href="#add-description">Add description</a>
+              <a id="addkeywords" data-desc="Insert comma separated keywords in My Bins" title="Add keywords to bin" class="button group" href="#add-keywords">Add keywords</a>
+
               <a title="Save snapshot" data-desc="Save current work, and begin new revision on next change" data-shortcut="ctrl+s" class="button save group" data-label="save" href="{{root}}/save">Save snapshot</a>
               <a data-desc="Copy and create a new bin start at revision #1" id="clone" title="Create a new copy" class="button clone group" data-label="clone" href="{{root}}/clone">Clone</a>
               <hr data-desc="">


### PR DESCRIPTION
So i mocked up the 2 main functionalities that need to be added to make this useful.

First, I added a filter input field and a select element, in the first you would be able to just type your keyword(s) to filter the whole list and only show the bins containing this / these keyword(s). Because this is part of the operation part of the page i added the 'control' class. This separates it better from the list of bins.

The elements need more styling, but wanted to poll reaction.

![screenshot 2015-09-20 15 04 24](https://cloud.githubusercontent.com/assets/474024/9980867/2dd19558-5fa9-11e5-9466-7cd390ab1f3f.png)

You see that in your bins the keywords are also shown, have to work out what to do with a lot of keywords, but that might be the next step. Of course this looks a bit crammed as well, but it might be an option to not show on snapshots or something like that. I moved the 'archive' link to the last column. 

(I personally really don't like how this is handled and is a bit confusing, so will see if i can come up with something better for that as well in a different branch.)

Next thing I did was basically copying the 'add description' functionality, so in the menu you will have a new option 'add keywords'.

![screenshot 2015-09-20 15 09 34](https://cloud.githubusercontent.com/assets/474024/9980876/b32dc532-5fa9-11e5-8f19-0bb4f0d04771.png)

What this does is almost exactly the same as with the 'add description', so the functions are copied and changed to suit the behaviour. I used the meta element for this as well to follow best HTML practices.
# Todo
- [ ] Add the keywords to the database and show them in history view
- [ ] Index the keywords for the user and generate select list from that
- [ ] Style the form elements according to the rest of Jsbin
- [ ] Maybe move all this bin description / keywords business to a new place so that it doesn't take up the whole menu and stays within the current bin context
