### PR TITLE
Changed D3.js to use https URL

### DIFF
--- a/public/js/editors/libraries.js
+++ b/public/js/editors/libraries.js
@@ -522,8 +522,8 @@ var libraries = [
     'label': 'Processing 1.4.1'
   },
   {
-    'url': 'http://d3js.org/d3.v3.min.js',
-    'label': 'D3 3.x'
+    'url': 'https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.6/d3.min.js',
+    'label': 'D3 3.5.6'
   },
   {
     'url': '//code.highcharts.com/highcharts.js',


### PR DESCRIPTION
Fixes #2549 - D3.js Library Not Loading on Bins Using Https

The D3 website doesn't serve the D3.js file over https so I've changed it to make use of cdnjs and specified the specific (latest) version.