### PR TITLE
Allow jsbin to run behind a proxy

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -98,7 +98,7 @@ if (!process.env.TZ && options.timezone) {
 
   // NOTE: this is *only* used for running the server.listen()
   // it's not used in the urls to access assets, etc.
-  options.port = port;
+  options.port = options.url.proxyPort || port;
 })();
 
 // Strip trailing slash from the prefix


### PR DESCRIPTION
Set the options.url.proxyPort to bind to a different port than the url.
This is needed to prevent resource location errors when behind a proxy.