### PR TITLE
Allow running inside OpenShift cloud

### DIFF
--- a/docs/session-keys.md
+++ b/docs/session-keys.md
@@ -16,3 +16,8 @@ key for you, you can choose to use this or one of your own. Just place it into y
     }
   }
 ```
+
+If you are running JS Bin in a OpenShift cloud instance, set the `JSBIN_SESSION_SECRET` [environment variable](https://developers.openshift.com/en/managing-environment-variables.html#custom-variables) instead, like so:
+```
+rhc env set JSBIN_SESSION_SECRET=mekYkYMlseZo6F8lOOgny2nA
+```

--- a/lib/addons/openshift.js
+++ b/lib/addons/openshift.js
@@ -1,0 +1,32 @@
+
+// Injects options if running inside an OpenShift cloud, from some OpenShift-
+// specific environment vars
+
+module.exports = function (options) {
+
+  if (!process.env.OPENSHIFT_APP_NAME) {
+    return;
+  }
+
+  process.env.PORT = process.env.OPENSHIFT_NODEJS_PORT;
+  options.host = process.env.OPENSHIFT_NODEJS_IP;  // Node shall listen on this network interface only
+  options.url.host = process.env.OPENSHIFT_APP_DNS;
+  options.url.ssl = true;
+
+  options.env = 'production';
+
+
+  // Set this with "rhc env set JSBIN_SESSION_SECRET [value]"
+  options.session.secret = process.env.JSBIN_SESSION_SECRET;
+
+
+  if (process.env.OPENSHIFT_MYSQL_VERSION) {
+    options.store.adapter = 'mysql';
+    options.store.mysql.host = process.env.OPENSHIFT_MYSQL_DB_HOST;
+    options.store.mysql.port = process.env.OPENSHIFT_MYSQL_DB_PORT;
+    options.store.mysql.username = process.env.OPENSHIFT_MYSQL_DB_USERNAME;
+    options.store.mysql.password = process.env.OPENSHIFT_MYSQL_DB_PASSWORD;
+    options.store.mysql.database = process.env.OPENSHIFT_APP_NAME;
+  }
+
+};

--- a/lib/app.js
+++ b/lib/app.js
@@ -6,6 +6,7 @@ var nodemailer  = require('nodemailer'),
     app         = express(),
     hbs         = require('./hbs'),
     options     = require('./config'),
+    openshift   = require('./addons/openshift')(options), // injects options from openshift env vars
     store       = require('./store')(options.store),
     undefsafe   = require('undefsafe'),
     models      = require('./models').createModels(store),
@@ -327,7 +328,7 @@ app.connect = function (callback) {
     }
 
     var port = app.set('port');
-    app.listen(port);
+    app.listen(port, options.host);	// options.host can be empty, meaning "bind to all network interfaces"
 
     if (typeof callback === 'function') {
       callback();

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "start": "(sleep 2 && open http://localhost:3000) & ./bin/jsbin",
     "test": "node_modules/mocha/bin/_mocha -t 25000 --ui bdd test/**/*.test.js",
     ":install": "build/install.js",
+    "postinstall": "grunt build",
     "preupdate": "node build/pre-update.js",
     "postupdate": "node build/post-update.js commit"
   },


### PR DESCRIPTION
After getting frustrated with trying to deploy JSBin in Heroku, I decided to go for OpenShift instead. Modifying the JSBin code to run there proved very simple:

- Fetch options from openshift env vars (if available)
- `grunt build` on postinstall
- Ensure `express` listens only on one network interface

With this, JSBin can just be pushed to a openshift git repo endpoint, and everything will run as expected.
