### PR TITLE
Solarized Dark Line Numbers

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1651,7 +1651,7 @@ THE SOFTWARE.
 
 /* Common */
 .cm-s-solarized .CodeMirror-linenumber {
-  color: rgba(88, 110, 117, 0.3);
+  color: #eee8d5;
 }
 
 


### PR DESCRIPTION
The line number coloring was difficult to read, changed to a shade of white for readability.

issue 2594