### PR TITLE
Remove RxJS 2, Add RxJS 5, update RxJS-DOM

### DIFF
--- a/public/js/editors/libraries.js
+++ b/public/js/editors/libraries.js
@@ -663,6 +663,11 @@ var libraries = [
     'group': 'RxJS'
   },
   {
+    'url': 'https://npmcdn.com/rx-dom@7.0.3/dist/rx.dom.js',
+    'label': 'rx.dom 7.0.3 (requires 4.x)',
+    'group': 'RxJS'
+  },
+  {
     'url': 'http://cdn.popcornjs.org/code/dist/popcorn.min.js',
     'label': 'Popcorn.js 1.5.6 (Core)',
     'group': 'Popcorn.js'

--- a/public/js/editors/libraries.js
+++ b/public/js/editors/libraries.js
@@ -663,21 +663,6 @@ var libraries = [
     'group': 'RxJS'
   },
   {
-    'url': 'https://cdnjs.cloudflare.com/ajax/libs/rxjs/2.3.22/rx.all.js',
-    'label': 'rx.all 2.3.22',
-    'group': 'RxJS'
-  },
-  {
-    'url': 'https://cdnjs.cloudflare.com/ajax/libs/rxjs/2.3.22/rx.testing.js',
-    'label': 'rx.testing 2.3.22',
-    'group': 'RxJS'
-  },
-  {
-    'url': 'https://cdnjs.cloudflare.com/ajax/libs/rxjs-dom/2.0.7/rx.dom.js',
-    'label': 'rx.dom 2.0.7',
-    'group': 'RxJS'
-  },
-  {
     'url': 'http://cdn.popcornjs.org/code/dist/popcorn.min.js',
     'label': 'Popcorn.js 1.5.6 (Core)',
     'group': 'Popcorn.js'

--- a/public/js/editors/libraries.js
+++ b/public/js/editors/libraries.js
@@ -648,6 +648,11 @@ var libraries = [
     'label': 'OpenTok v2.x (latest)'
   },
   {
+    'url': 'https://npmcdn.com/@reactivex/rxjs@5.0.0-alpha.8/dist/global/Rx.js',
+    'label': 'RxJS 5.0.0-alpha.8',
+    'group': 'RxJS'
+  },
+  {
     'url': 'https://cdnjs.cloudflare.com/ajax/libs/rxjs/4.0.6/rx.all.js',
     'label': 'rx.all 4.0.6',
     'group': 'RxJS'


### PR DESCRIPTION
- removes RxJS 2.x links... They're pretty old and people should be using 4.x in production right now.
- updates RxJS-DOM to 7.x ... this is the latest version, and requires RxJS 4.x
- adds link for RxJS 5.0.0-alpha.8 ... RxJS 5 is a total rewrite of RxJS that is meant to be faster and align with the [ES7 Observable Spec](https://github.com/zenparsing/es-observable). As such, the API is quite different, and we'd love for people to be able to play with it in JSBin. It's also used for Angular 2.

Really appreciate the help and the service, @remy and others! 🍻