### PR TITLE
Make setting es6/babel as a preprocessor work when pre-populating bins with POST request

### DIFF
--- a/lib/handlers/bin.js
+++ b/lib/handlers/bin.js
@@ -41,7 +41,7 @@ module.exports = Observable.extend({
     this.renderFiles(req, res, next);
   },
   getFromPost: function (req, res, next) {
-    var processorTypes = 'jade markdown less stylus sass scss coffeescript processing traceur typescript jsx'.split(' '),
+    var processorTypes = 'jade markdown less stylus sass scss coffeescript processing traceur typescript jsx babel'.split(' '),
         aliases = processors.aliases,
         allTypes = ('html css javascript'.split(' ')).concat(processorTypes).concat(Object.keys(aliases));
 

--- a/lib/processors/index.js
+++ b/lib/processors/index.js
@@ -60,8 +60,8 @@ var processors = {
     'sass': 'css',
     'scss': 'css',
     'myth': 'css',
-    'babel': 'js',
-    'es6': 'js',
+    'babel': 'javascript',
+    'es6': 'javascript',
   },
 };
 


### PR DESCRIPTION
For some reason didn't work before 