### PR TITLE
Update keyboard shortcuts help text

### DIFF
--- a/views/index.html
+++ b/views/index.html
@@ -209,11 +209,11 @@ Include alerts, prompts &amp; confirm boxes">Run with JS</button>
           <td>Toggle comment on selected lines</td>
         </tr>
         <tr>
-          <td>ctrl + [</td>
+          <td>ctrl + ]</td>
           <td>Indents selected lines</td>
         </tr>
         <tr>
-          <td>ctrl + ]</td>
+          <td>ctrl + [</td>
           <td>Unindents selected lines</td>
         </tr>
         <tr>


### PR DESCRIPTION
This updates the keyboard shortcuts help text for indenting and unindenting to be correct, as reported in #2553