### PR TITLE
Make typescript work without System.js

### DIFF
--- a/public/js/processors/processor.js
+++ b/public/js/processors/processor.js
@@ -262,7 +262,6 @@ var processors = jsbin.processors = (function () {
           compilerOptions: {
             inlineSourceMap: true,
             inlineSources: true,
-            module: ts.ModuleKind.System,
             target: ts.ScriptTarget.ES5
           },
           fileName: 'jsbin.ts',


### PR DESCRIPTION
Part of the future PR sneaked in into #2636

Having this doesn't require to have System.js loaded to work with typescript. 