### PR TITLE
[Proposal] Running Angular2/TypeScript in JsBin

### DIFF
--- a/public/js/processors/processor.js
+++ b/public/js/processors/processor.js
@@ -271,6 +271,7 @@ var processors = jsbin.processors = (function () {
             target: ts.ScriptTarget.ES5
           },
           fileName: 'jsbin.ts',
+          moduleName: 'jsbin.ts',
           reportDiagnostics: true
         });
 
@@ -294,29 +295,8 @@ var processors = jsbin.processors = (function () {
               ' (' + diagnostic.file.fileName + ':'+line+':'+character+')';
           }).join('\n'));
         } else {
-          var before =
-            "(function(){" +
-            "var tempRegister;" +
-            "if (typeof System === 'undefined') {" +
-            "  System = {};" +
-            "}" +
-            "if (typeof System.register === 'function') {" +
-            "  tempRegister = System.register;" +
-            "  System.register = System.register.bind(System, 'jsbin.ts');" +
-            "} else {" +
-            "  System.register = function(deps, module) {" +
-            "    module().execute();" +
-            "  }" +
-            "}";
-
-          var after =
-            "if(typeof System.import === 'function'){" +
-            "  System.register = tempRegister;"+
-            "  System.import('jsbin.ts');" +
-            "};" +
-            "}());";
-
-          resolve(before + result.outputText + after);
+          var after = "System.import('jsbin.ts')";
+          resolve(result.outputText + after);
         }
       }
     }),


### PR DESCRIPTION
With #2636 we're one step closer to being able to run Angular2/TypeScript in JsBin.

However we still need to teach typescript how to handle module imports correctly, e.g.

``` typescript
import {bootstrap, Component} from 'angular2/angular2';
```
# POC Implementation

I've created a quick POC, to make sure it's possible to make it work. 
## During generation

 When compiling TS specify target as [ts.ModuleKind.System](https://github.com/kirjs/jsbin/commit/a0c0a2eda7ac10dc99286a4026af69d647618f57#diff-11e4e4675ce028bd0b3f85cb0b8bb728R270)
## After generation

Typescript generates anonymous module with has to be executed somehow. 
So prepend the code with some logic to fake System.register to [register the module with a name](https://github.com/kirjs/jsbin/commit/a0c0a2eda7ac10dc99286a4026af69d647618f57#diff-11e4e4675ce028bd0b3f85cb0b8bb728R305) if System.js was loaded, or [execute the code right away](https://github.com/jsbin/jsbin/pull/2646/files#diff-11e4e4675ce028bd0b3f85cb0b8bb728R308) if not. 
# POC Drawbacks

Current implementation has several drawbacks: 
- Altering the generated code breaks source maps, so they also have to be updated somehow. I found this being done in other places in the code. See https://github.com/jsbin/jsbin/issues/2648
- Code shouldn't be stored in a string because it looks ugly. 
- The actual implementation looks like a big hack. 
- This solution assumes System.js, and typescript combination, and won't work for let's say babel and System.js. It could probably make sense to have it in the other place in the up. 
## What's next

This PR shouldn't be merged in as it is, but is here to open the discussion.

I'd love to get some input from TypeScript/SystemJS people on how to improve 
And from @remy on where this would fit in the app. 
And from Angular people in case there is a simpler way of doing the same. 
