### PR TITLE
Prototype for showing runtime errors in codemirror

### DIFF
--- a/public/js/render/live.js
+++ b/public/js/render/live.js
@@ -193,10 +193,13 @@ var renderer = (function () {
   };
 
   /**
-   * Pass loop protection hit calls up to the error UI
+   * Pass loop protection hit calls and runtime errors 
+   * up to the error UI
    */
-  renderer.loopProtectHit = function (line) {
+  renderer.showIssue = function (data) {
     var cm = jsbin.panels.panels.javascript.editor;
+    var type = data.type;
+    var line = data.line;
 
     // grr - more setTimeouts to the rescue. We need this to go in *after*
     // jshint does it's magic, but jshint set on a setTimeout, so we have to
@@ -206,14 +209,14 @@ var renderer = (function () {
       if (typeof cm.updateLinting !== 'undefined') {
         // note: this just updated the *source* reference
         annotations = annotations.filter(function (a) {
-          return a.source !== 'loopProtectLine:' + line;
+          return a.source !== type + 'Line:' + line;
         });
         annotations.push({
           from: CodeMirror.Pos(line-1, 0),
           to: CodeMirror.Pos(line-1, 0),
-          message: 'Exiting potential infinite loop.\nTo disable loop protection: add "// noprotect" to your code',
-          severity: 'warning',
-          source: 'loopProtectLine:' + line
+          message: data.message,
+          severity: data.severity,
+          source:  type + 'Line:' + line
         });
 
         cm.updateLinting(annotations);


### PR DESCRIPTION
Hi, I'd like to add functionality to show runtime errors in the codemirror frame (similar to the endless loop warning and lint errors). 

Background: Jsbin seems ideal for learning JS, but finding errors in the JS console adds an additional hurdle for beginners, and the console takes up a lot of space on small screens. 

I have created a proof of concept in this pull request, would like to get feedback on
- whether you think this is a reasonable improvement
- what's needed for an initial version 

Known issues:
- The existing endless loop detection code adds additional lines, which breaks the mapping. I think this can be fixed by making sure the endless loop detection doesn't add additional code lines
- The line numbers are off in FF -- I think it starts counting at the start of the file instead of the start of the corresponding script tag. This should be fixable, too, e.g. by handing over the position from the processor somehow.
- I have only tested this on Chrome and Firefox on Ubuntu 15.10 so far.
