### PR TITLE
docs: fix typos

### DIFF
--- a/docs/running-your-own-jsbin.md
+++ b/docs/running-your-own-jsbin.md
@@ -16,7 +16,7 @@ Historically, JS Bin v1, v2 and the first release of v3 had support for PHP. **P
 
 ### Node
 
-Install Node first (Node version 0.10.27 will work, no gurantee on later versions) this will give you the `node` and `npm` programs.
+Install Node first (Node version 0.10.27 will work, no guarantee on later versions) this will give you the `node` and `npm` programs.
 
 You can (and should) install JS Bin with `npm` using the following command:
 
@@ -92,7 +92,7 @@ JS Bin's build process uses Grunt, so assuming you've cloned a copy, you will ne
 
 This will generate the `public/js/prod/` directory and read the version in the `package.json` file to generate to build a number of files:
 
-1. jsbin-<version>.js - the uncompressed, concatted version of all the scripts from `/scripts.json`
+1. jsbin-<version>.js - the uncompressed, concatenated version of all the scripts from `/scripts.json`
 2. jsbin-<version>.min.js - the production compressed version of jsbin, used in the editor
 3. jsbin.map.json - the sourcemaps file (useful for debugging in live)
 4. runner-<version>.js - the runner script, used to generate the output of the user's code in an iframe


### PR DESCRIPTION
`gurantee` → `guarantee`
`concatted` → `concatenated`