### PR TITLE
upgrade lodash to 4.5.1

### DIFF
--- a/public/js/editors/libraries.js
+++ b/public/js/editors/libraries.js
@@ -513,8 +513,8 @@ var libraries = [
     'label': 'Less 1.3.3'
   },
   {
-    'url': 'https://cdn.rawgit.com/lodash/lodash/3.0.1/lodash.min.js',
-    'label': 'lodash 3.0.1'
+    'url': 'https://cdn.rawgit.com/lodash/lodash/4.5.1/dist/lodash.min.js',
+    'label': 'lodash 4.5.1'
   },
   {
     'url': 'http://modernizr.com/downloads/modernizr-latest.js',


### PR DESCRIPTION
![lodash-451](https://cloud.githubusercontent.com/assets/2513462/13217348/ede45872-d9b5-11e5-9d3c-283c7c4ceb08.png)

Current jsbin version is 3.0.1. 3.0.1 docs are no longer listed on the lodash website. You have to go to the tagged source on github.


This example of `_.has` taken from the lodash docs for the latest version returns `false` instead of `true`. (3.0.1 does not support nested object checks).

```
_.has({ 'a': { 'b': { 'c': 3 } } }, 'a.b.c');
```