### PR TITLE
React 0.14.7

### DIFF
--- a/public/custom/react/default.html
+++ b/public/custom/react/default.html
@@ -4,8 +4,8 @@
   <meta charset="utf-8">
   <title>React</title>
   <link rel="stylesheet" href="http://cdnjs.cloudflare.com/ajax/libs/normalize/3.0.1/normalize.css">
-  <script src="//fb.me/react-with-addons-0.14.3.js"></script>
-  <script src="//fb.me/react-dom-0.14.3.js"></script>
+  <script src="//fb.me/react-with-addons-0.14.7.min.js"></script>
+  <script src="//fb.me/react-dom-0.14.7.min.js"></script>
 </head>
 <body>
   <div id="container"></div>

--- a/public/js/editors/libraries.js
+++ b/public/js/editors/libraries.js
@@ -354,22 +354,22 @@ var libraries = [
     'group': 'Angular'
   },
   {
-    'url': ['//fb.me/react-0.14.3.js', '//fb.me/react-dom-0.14.3.js'],
-    'label': 'React 0.14.3',
+    'url': ['https://fb.me/react-0.14.7.min.js', 'https://fb.me/react-dom-0.14.7.min.js'],
+    'label': 'React 0.14.7',
     'group': 'React'
   },
   {
-    'url': ['//fb.me/react-with-addons-0.14.3.js', '//fb.me/react-dom-0.14.3.js'],
-    'label': 'React with Add-Ons 0.14.3',
+    'url': ['https://fb.me/react-with-addons-0.14.7.min.js', 'https://fb.me/react-dom-0.14.7.min.js'],
+    'label': 'React with Add-Ons 0.14.7',
     'group': 'React'
   },
   {
-    'url': '//fb.me/react-0.13.3.js',
+    'url': 'https://fb.me/react-0.13.3.js',
     'label': 'React 0.13.3',
     'group': 'React'
   },
   {
-    'url': '//fb.me/react-with-addons-0.13.3.js',
+    'url': 'https://fb.me/react-with-addons-0.13.3.js',
     'label': 'React with Add-Ons 0.13.3',
     'group': 'React'
   },


### PR DESCRIPTION
Facebook's CDN was failing for React 0.14.3. Updating to the latest 0.14.x seemed to fix it. Multiple incidents like this have been reported to me at [my page](http://reactfordesigners.com/labs/reactjs-introduction-for-people-who-know-just-enough-jquery-to-get-by/):

https://twitter.com/chibicode/status/706187916670701569
