### PR TITLE
Add missing jQueries, drop jQuery Compat

### DIFF
--- a/public/js/editors/libraries.js
+++ b/public/js/editors/libraries.js
@@ -5,8 +5,13 @@ var libraries = [
     'group': 'jQuery'
   },
   {
-    'url': 'https://code.jquery.com/jquery-3.0.0-alpha1.js',
-    'label': 'jQuery 3.0.0-alpha1',
+    'url': 'https://code.jquery.com/jquery-3.0.0-beta1.js',
+    'label': 'jQuery 3.0.0-beta1',
+    'group': 'jQuery'
+  },
+  {
+    'url': 'https://code.jquery.com/jquery-2.2.3.js',
+    'label': 'jQuery 2.2.3',
     'group': 'jQuery'
   },
   {
@@ -15,18 +20,23 @@ var libraries = [
     'group': 'jQuery'
   },
   {
-    'url': 'https://code.jquery.com/jquery-compat-git.js',
-    'label': 'jQuery Compat WIP (via git)',
+    'url': 'https://code.jquery.com/jquery-2.0.3.js',
+    'label': 'jQuery 2.0.3',
     'group': 'jQuery'
   },
   {
-    'url': 'https://code.jquery.com/jquery-compat-3.0.0-alpha1.js',
-    'label': 'jQuery Compat 3.0.0-alpha1',
+    'url': 'https://code.jquery.com/jquery-1.12.3.js',
+    'label': 'jQuery 1.12.3',
     'group': 'jQuery'
   },
   {
     'url': 'https://code.jquery.com/jquery-1.11.3.js',
     'label': 'jQuery 1.11.3',
+    'group': 'jQuery'
+  },
+  {
+    'url': 'https://code.jquery.com/jquery-1.10.2.js',
+    'label': 'jQuery 1.10.2',
     'group': 'jQuery'
   },
   {


### PR DESCRIPTION
1. Add the new jQuery 2.2.3/1.12.3
2. Drop jQuery Compat as we've decided to not release it at all, there's only been one alpha and this version is now abandoned, the WIP URL is redirecting to the main one.
3. Add jQuery 1.10.2 & 2.0.3, they were missing for some reason.