### PR TITLE
Password reset message improvements (incl. email address leakage)

### DIFF
--- a/lib/handlers/session.js
+++ b/lib/handlers/session.js
@@ -256,7 +256,7 @@ module.exports = Observable.extend({
 
         // Send email.
         sessionHandler.mailer.forgotPassword(user.email, ctx, function (err) {
-          var flash = 'An email has been sent to ' + user.email,
+          var flash = 'An email has been sent to the address associated with your account.',
               type = req.flash.NOTIFICATION;
 
           if (err && err instanceof errors.MailerError) {

--- a/public/js/login.js
+++ b/public/js/login.js
@@ -137,7 +137,7 @@
           }
         });
       } else {
-        showInfo().find('p').text('Please enter your username or email address above, and I\'ll try to find you and send you a reset token.');
+        showInfo().find('p').text('Please enter your username or email address below, and I\'ll try to find you and send you a reset token.');
       }
 
     }, 1000);


### PR DESCRIPTION
This pull request addresses two minor details related to the password reset mechanism.

1. Requesting a password reset results in the email address associated with the account being output in the success notification. There is the potential for misuse, allowing the email address associated with a JS Bin account to be obtained by knowing only the username. This PR genericises the success notification and removes the email from the output.
<img width="267" alt="Screenshot displaying success notification with email address redacted" src="https://cloud.githubusercontent.com/assets/291675/15836132/463d3300-2c2b-11e6-8393-a19ddc8a7e7a.png">

2. Requesting a password reset without entering an email address or username results in a validation error. The text refers to the email/username input being above the message. This PR corrects this, as the input field is below the validation message.
<img width="276" alt="Screen shot showing the validation message, highlighting the above word and showing that the username field is actually below the message." src="https://cloud.githubusercontent.com/assets/291675/15836251/c9c987be-2c2b-11e6-923a-a52e506d15f5.png">

