### PR TITLE
Add esnext.jsbin.com

### DIFF
--- a/public/custom/esnext/config.json
+++ b/public/custom/esnext/config.json
@@ -1,0 +1,9 @@
+{
+  "settings": {
+    "panels": ["javascript", "console"]
+  },
+  "processors": {
+    "javascript": "es6"
+  },
+  "name": "ESNext"
+}

--- a/public/custom/esnext/default.html
+++ b/public/custom/esnext/default.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>ESNext</title>
+</head>
+<body>
+  
+</body>
+</html>

--- a/public/custom/esnext/default.js
+++ b/public/custom/esnext/default.js
@@ -1,0 +1,1 @@
+/* jshint esnext: true */


### PR DESCRIPTION
As per the twitter conversation between me (@mxstbr) and @js_bin today, this adds esnext.jsbin.com. I found myself doing those steps over and over when using JSBin, so I figured making this an official shortcut would be nice!

Not sure if there's anything else needed, I mostly copied what the people did for react.jsbin.com! Let me know!
