### PR TITLE
feat(Library): Add lodash fp and update lodash

### DIFF
--- a/public/js/editors/libraries.js
+++ b/public/js/editors/libraries.js
@@ -537,8 +537,19 @@ var libraries = [
     'label': 'Less 1.3.3'
   },
   {
-    'url': 'https://cdn.rawgit.com/lodash/lodash/4.5.1/dist/lodash.min.js',
-    'label': 'lodash 4.5.1'
+    'url': 'https://cdn.jsdelivr.net/lodash/4/lodash.min.js',
+    'label': 'lodash 4.x',
+    'group': 'Lodash'
+  },
+  {
+    'url': 'https://cdn.jsdelivr.net/g/lodash@4(lodash.min.js+lodash.fp.min.js)',
+    'label': 'lodash fp 4.x',
+    'group': 'Lodash'
+  },
+  {
+    'url': 'https://cdn.jsdelivr.net/lodash/3/lodash.min.js',
+    'label': 'lodash 3.x',
+    'group': 'Lodash'
   },
   {
     'url': 'http://modernizr.com/downloads/modernizr-latest.js',


### PR DESCRIPTION
**lodash fp** is the functional variant of **lodash** library similar to **Ramda** library
:point_right: **https://github.com/lodash/lodash/wiki/FP-Guide**

- [x] Update to use latest lodash - 4.x
- [x] Add lodash fp 4.x (use the latest)
- [x] Add lodash 3.x (use latest)

Grouped as "Lodash"

:white_check_mark: Locally tested 
:loop: Using [**jsDelivr**](http://www.jsdelivr.com/?query=lodash) as CDN

&nbsp;
> **NOTE 1:** Added lodash 3.x as many companies still use lodash 3.x and have not yet upgraded to lodash 4.x (_due to breaking changes_)

&nbsp;
> **NOTE 2:** Lodash FP is basically combination of [lodash main ](https://cdn.jsdelivr.net/lodash/4/lodash.min.js) with [lodash fp](https://cdn.jsdelivr.net/lodash/4/lodash.fp.min.js). I've used a grouped CDN url so that only a single script tag is used for adding lodash fp.
If needed, I can separate it to add two script tags i.e.

> ```html
<script src="https://cdn.jsdelivr.net/lodash/4/lodash.min.js"></script>
<script src="https://cdn.jsdelivr.net/lodash/4/lodash.fp.min.js"></script>
```

> instead of (_following is the current behavior as per the PR_)

> ```html
<script src="https://cdn.jsdelivr.net/g/lodash@4(lodash.min.js+lodash.fp.min.js)"></script>
```

### Screenshot
> [![Local lodash group screenshot](http://i.imgur.com/q1c27gC.png)](http://i.imgur.com/q1c27gC.png)

----
https://github.com/jsbin/jsbin/issues/2839#issuecomment-238107128

After this is merged, it won't ever be required to update lodash manually for minor/patch versions  :smile: :joy: 

// cc: @remy 