### PR TITLE
Update Blaze CDN link

### DIFF
--- a/public/js/editors/libraries.js
+++ b/public/js/editors/libraries.js
@@ -730,7 +730,7 @@ var libraries = [
   },
   {
     'url': [
-      'https://unpkg.com/blaze/dist/blaze.min.css'
+      'https://unpkg.com/blaze/dist/blaze.min.css',
       'https://unpkg.com/blaze/dist/blaze.colors.min.css'
     ],
     'label': 'Blaze CSS (latest)'

--- a/public/js/editors/libraries.js
+++ b/public/js/editors/libraries.js
@@ -730,7 +730,7 @@ var libraries = [
   },
   {
     'url': [
-      'https://unpkg.com/blaze',
+      'https://unpkg.com/blaze/dist/blaze.min.css'
       'https://unpkg.com/blaze/dist/blaze.colors.min.css'
     ],
     'label': 'Blaze CSS (latest)'


### PR DESCRIPTION
This prevents the link being mistaken for JavaScript file rather than a CSS file.

Both:
https://unpkg.com/blaze
and
https://unpkg.com/blaze/dist/blaze.min.css

Resolve to the same thing but the editor thinks the first URL is a script URL
