### PR TITLE
fix: Add Vue JS 2.0.3 library

### DIFF
--- a/public/js/editors/libraries.js
+++ b/public/js/editors/libraries.js
@@ -423,7 +423,11 @@ var libraries = [
   },
   {
     'url': 'https://cdnjs.cloudflare.com/ajax/libs/vue/1.0.16/vue.js',
-    'label': 'Vue.js',
+    'label': 'Vue.js 1.0.16',
+  },
+  {
+    'url': 'https://cdnjs.cloudflare.com/ajax/libs/vue/2.0.3/vue.js',
+    'label': 'Vue.js 2.0.3',
   },
   {
     'url': 'http://cdn.ractivejs.org/latest/ractive.js',


### PR DESCRIPTION
Some projects still use Vue 1, but version 2 was recently released 😄 