### PR TITLE
feat: allow whitelisted referrers in embeds

### DIFF
--- a/lib/features.js
+++ b/lib/features.js
@@ -24,6 +24,8 @@ var undefsafe = require('undefsafe');
 var _ = require('underscore');
 var config = require('./config');
 
+var embedWhiteList = undefsafe(config, 'security.embedWhiteList') || [];
+
 var teamjsbin = ['allouis', 'yandle', 'rem'];
 var alphausers = teamjsbin.concat(['electric_g', 'sil', 'slexaxton', 'reybango', 'phuu', 'agcolom', 'glennjones', 'rossbruniges', 'andrewnez', 'chrismahon', 'brianleroux', 'jed', 'iancrowther', 'jakearchibald']);
 
@@ -159,7 +161,15 @@ var flags = {
 
   sslForEmbeds: function (req) { // 2015-06-07
     var sslForBin = pro({ session: { user: undefsafe(req, 'bin.metadata') }});
-    return (pro(req) && undefsafe(req, 'session.user.settings.ssl')) || sslForBin;
+
+    var referer = req.get('Referrer'); // http://expressjs.com/en/4x/api.html#req.get
+    var whitelisted = referer ? embedWhiteList.some(function (url) {
+      return url.indexOf(referer) === 0;
+    }) : false;
+
+    return (pro(req) && undefsafe(req, 'session.user.settings.ssl')) ||
+      sslForBin ||
+      whitelisted;
   },
 
   fileMenuTest: true, // live 2014-05-27 - #1414

--- a/test/unit/features.test.js
+++ b/test/unit/features.test.js
@@ -1,0 +1,37 @@
+var proxyquire = require('proxyquire');
+var test = require('tap').test;
+var features = proxyquire('../../lib/features', {
+  './config': {
+    security: {
+      embedWhiteList: ['https://foo.com']
+    }
+  }
+});
+
+test('whitelist works', function (t) {
+  var req = {
+    headers: {
+      referrer: 'https://foo.com'
+    },
+    get: function (key) {
+      return req.headers[key.toLowerCase()];
+    }
+  };
+
+  var res = features('sslForEmbeds', req);
+  t.equal(res, true, 'foo.com allowed');
+
+  req.headers.referrer = 'http://bar.com';
+  res = features('sslForEmbeds', req);
+  t.equal(res, false, 'bar.com disallowed');
+
+  req.headers.referrer = '';
+  res = features('sslForEmbeds', req);
+  t.equal(res, false, 'no referrer disallowed');
+
+  req.headers.referrer = 'http://fooy.com';
+  res = features('sslForEmbeds', req);
+  t.equal(res, false, 'close referrer disallowed');
+
+  t.end();
+});


### PR DESCRIPTION
Specifically for training companies that support jsbin