### PR TITLE
moved card attribution to the ads bar to keep Output clean

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -3136,10 +3136,9 @@ html * {
 
 .card {
   z-index: 10;
-  position: absolute;
-  bottom: 12px;
-  right: 12px;
-  float: left;
+  position: fixed;
+  bottom: 0px;
+  right: 0px;
   font-family: system, "Helvetica Neue", sans-serif;
   font-weight: 400;
   background: #fafafa;
@@ -3153,8 +3152,7 @@ html * {
   display: inline-block;
   box-sizing: border-box;
   /*margin: 10px;*/
-  border: 1px solid #fff;
-  box-shadow: 0px 0px 2px rgba(0, 0, 0, 0.2);
+  border: solid 1px #bfbfbf;
   font-size: 16px;
   /* min-width: 500px; */
 }
@@ -3196,7 +3194,7 @@ html * {
   cursor: pointer;
   display: block;
   box-sizing: border-box;
-  height: 48px;
+  height: 30px;
   white-space: nowrap;
   overflow: visible;
   /*overflow-x: auto;*/
@@ -3315,6 +3313,7 @@ html * {
 }
 
 .card .name {
+  float: left;
   margin-bottom: 2px;
 }
 
@@ -3332,10 +3331,10 @@ html * {
 }
 
 .card img {
-  margin: 5px;
-  padding: 5px;
+  margin: 0 5px;
+  padding: 0 5px;
   float: left;
-  width: 30px;
+  height: 30px;
 }
 
 .card.anonymous header img {
@@ -3402,7 +3401,7 @@ html * {
 .card .viewers span {
   color: rgba(0,0,0,.4);
   font-weight: 800;
-  font-size: 12px;
+  font-size: 21px;
   line-height:16px;
   display: block;
 }


### PR DESCRIPTION
[Linked to issue #2897](https://github.com/jsbin/jsbin/issues/2897)

@remy I have taken the comments from **Susi** and made a few simple css tweaks to give the user the Output view without any blockages like **Susi** was experiencing.

**Current live** 
<img width="344" alt="screen shot 2016-11-24 at 23 00 28" src="https://cloud.githubusercontent.com/assets/22435712/20610967/d458bc5a-b299-11e6-8521-9bb43a9c8616.png">

**Proposed edit**
<img width="440" alt="screen shot 2016-11-24 at 22 51 51" src="https://cloud.githubusercontent.com/assets/22435712/20610957/b249de1e-b299-11e6-9a2e-a8b00e7de913.png">
<img width="462" alt="screen shot 2016-11-24 at 22 51 57" src="https://cloud.githubusercontent.com/assets/22435712/20610958/b24c8ccc-b299-11e6-8cbb-48f5461d0811.png">
