### PR TITLE
Fix for #2833, console.assert wrong output

### DIFF
--- a/public/js/render/console.js
+++ b/public/js/render/console.js
@@ -266,6 +266,17 @@ window._console = {
   clear: function () {
     output.innerHTML = '';
   },
+  assert: function() { 
+    if (arguments.length === 0  || !eval(arguments[0])) {
+      var msg = [];
+      for(var p in arguments) {
+          if (p === "0") continue;
+          msg.push(arguments[p]);
+      }
+      var assertionMsg = msg.join(' ') || 'console.assert'
+      log('Assertion failed: '+assertionMsg, 'error');
+    }
+  },
   log: function () {
     var l = arguments.length, i = 0;
     for (; i < l; i++) {


### PR DESCRIPTION
Matched chrome's assertions:

Original:
![image](https://cloud.githubusercontent.com/assets/4612707/20912425/e1c0696c-bb34-11e6-9e77-f46a930d489c.png)

After fix:
![image](https://cloud.githubusercontent.com/assets/4612707/20912431/eb28e948-bb34-11e6-8e22-69dd97fb89a8.png)
