### PR TITLE
Updated OpenUI5 library entry to latest theme

### DIFF
--- a/public/js/editors/libraries.js
+++ b/public/js/editors/libraries.js
@@ -684,10 +684,10 @@ var libraries = [
     'url': {
       'url': 'https://openui5.hana.ondemand.com/resources/sap-ui-core.js',
       'id': 'sap-ui-bootstrap',
-      'data-sap-ui-theme': 'sap_bluecrystal',
+      'data-sap-ui-theme': 'sap_belize',
       'data-sap-ui-libs': 'sap.m'
     },
-    'label': 'OpenUI5 latest (Mobile BlueCrystal)'
+    'label': 'OpenUI5 CDN (belize Theme, mobile library)'
   },
   {
     'url': 'https://cdnjs.cloudflare.com/ajax/libs/gsap/1.11.7/TweenMax.min.js',


### PR DESCRIPTION
- sap_belize is the new default for OpenUI5 since version 1.40
- the URL is our CDN (Content Delivery Network)
- switched order of description

I am from the UI5 team, in case of questions please contact me at mi.graf@sap.com, thank you!