### PR TITLE
Library - Update RxJs 5.0.0-beta to 5.0.3 final

### DIFF
--- a/public/js/editors/libraries.js
+++ b/public/js/editors/libraries.js
@@ -740,8 +740,8 @@ var libraries = [
     'label': 'Blaze CSS (latest)'
   },
   {
-    'url': 'https://unpkg.com/@reactivex/rxjs@5.0.0-beta.7/dist/global/Rx.umd.js',
-    'label': 'RxJS 5.0.0-beta.7',
+    'url': 'https://unpkg.com/@reactivex/rxjs@5.0.3/dist/global/Rx.js',
+    'label': 'RxJS 5.0.3',
     'group': 'RxJS'
   },
   {


### PR DESCRIPTION
RxJs 5 has been released