### PR TITLE
add Mapbox GL JS library

### DIFF
--- a/public/js/editors/libraries.js
+++ b/public/js/editors/libraries.js
@@ -599,6 +599,14 @@ var libraries = [
     'group': 'D3'
   },
   {
+    'url': [
+      'https://api.tiles.mapbox.com/mapbox-gl-js/v0.34.0/mapbox-gl.css',
+      'https://api.tiles.mapbox.com/mapbox-gl-js/v0.34.0/mapbox-gl.js'
+    ],
+    'label': 'Mapbox GL JS 0.34.0',
+    'group': 'Mapbox'
+  },
+  {
     'url': '//code.highcharts.com/highcharts.js',
     'label': 'Highcharts latest'
   },

--- a/public/js/editors/libraries.js
+++ b/public/js/editors/libraries.js
@@ -600,10 +600,10 @@ var libraries = [
   },
   {
     'url': [
-      'https://api.tiles.mapbox.com/mapbox-gl-js/v0.34.0/mapbox-gl.css',
-      'https://api.tiles.mapbox.com/mapbox-gl-js/v0.34.0/mapbox-gl.js'
+      'https://unpkg.com/mapbox-gl/dist/mapbox-gl.css',
+      'https://unpkg.com/mapbox-gl/dist/mapbox-gl.js'
     ],
-    'label': 'Mapbox GL JS 0.34.0',
+    'label': 'Mapbox GL JS',
     'group': 'Mapbox'
   },
   {


### PR DESCRIPTION
[Mapbox GL JS](https://www.mapbox.com/mapbox-gl-js/api/) is a JavaScript library that uses WebGL to render interactive maps from vector tiles and Mapbox styles.