### PR TITLE
Fixed broken links and file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ JS Bin allows you to edit and test JavaScript and HTML (reloading the URL also m
 
 The original idea spawned from a conversation with another developer in trying to help him debug an Ajax issue. The original aim was to build it using Google's app engine, but in the end, it was [John Resig](http://ejohn.org)'s [Learning app](http://ejohn.org/apps/learn) that inspired me to build the whole solution in JavaScript with liberal dashes of jQuery and a tiny bit of LAMP for the saving process.
 
-[Version 1](http://1.jsbin.com) of [JS Bin](http://www.flickr.com/photos/remysharp/4284906136) took me the best part of 4 hours to develop [back in 2008](http://remysharp.com/2008/10/06/js-bin-for-collaborative-javascript-debugging/), but [version 2](http://2.jsbin.com) was been rewritten from the ground up and is completely [open source](http://github.com/remy/jsbin).
+[Version 1](http://www.flickr.com/photos/remysharp/4284906136) of JS Bin took me the best part of 4 hours to develop [back in 2008](http://remysharp.com/2008/10/06/js-bin-for-collaborative-javascript-debugging/), but version 2 was been rewritten from the ground up and is completely [open source](http://github.com/remy/jsbin).
 
 ## Build Process
 


### PR DESCRIPTION
The 1.jsbin.com and 2.jsbin.com appeared to go to v4 so I changed it and make .markdown to .md