### PR TITLE
Fix Typos

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -38,7 +38,7 @@
 # Save
 
 - Add gist support back in (but do it server side) - support Lea's dabblet format (but files named jsbin.html, etc)
-- Fork (as well as clone) and folk allows me to trace this heirachy of bins saved to get to this point
+- Fork (as well as clone) and folk allows me to trace this hierarchy of bins saved to get to this point
 
 # Misc
 

--- a/docs/ie8.md
+++ b/docs/ie8.md
@@ -14,4 +14,4 @@
 - Include jQuery and it goes to shit
 - Restored panels always maximise
 - Layout of profile when logged in wrong
-- Dynamically change "create milestone" to "save" for first run in IE8 - then refresh should yeild a checksum
+- Dynamically change "create milestone" to "save" for first run in IE8 - then refresh should yield a checksum

--- a/docs/post.md
+++ b/docs/post.md
@@ -37,7 +37,7 @@ JS Bin can do this. Simply point the device or browser to your full preview URL 
 
 The URL structure even has a shortcut if you're [registered](http://jsbin.com/#register) you can always point the URL to [http://jsbin.com/<username>/last](http://jsbin.com/rem/last) and it'll pull up the last bin you've worked on.
 
-Along with live remote rendering, I've been working with the Adobe Shadow team and they've gone ahead and built in compatability with JS Bin directly into Shadow. This  simply means that when you visit jsbin.com on your desktop, Shadow will automatically show you the rendered output ([here's a demo with their beta software]()).
+Along with live remote rendering, I've been working with the Adobe Shadow team and they've gone ahead and built in compatibility with JS Bin directly into Shadow. This  simply means that when you visit jsbin.com on your desktop, Shadow will automatically show you the rendered output ([here's a demo with their beta software]()).
 
 ### How the live stuff works
 
@@ -47,7 +47,7 @@ As you type, we send an Ajax save request (after an idle time of 200ms). On the 
 
 When viewing the CodeCasting URL or the live remote rendering, each user is connected to our Spike program. This listens for the event that says a bin has changed, and when that happens, it just finds all the users watching a particular url, and sends them the updated panel (so we only send the CSS panel if the CSS panel changed).
 
-An [EventSource](http://html5doctor.com/server-sent-events/) maintains a persistent connection with the server and is listening for those events in the browser. When the event is recieved, depending on the content type, it'll either inject the content live, or refresh the page giving you the latest code.
+An [EventSource](http://html5doctor.com/server-sent-events/) maintains a persistent connection with the server and is listening for those events in the browser. When the event is received, depending on the content type, it'll either inject the content live, or refresh the page giving you the latest code.
 
 
 

--- a/docs/running-your-own-jsbin.md
+++ b/docs/running-your-own-jsbin.md
@@ -83,7 +83,7 @@ Now the `jsbin` node process is listening on port 8000, but the client facing ur
 
 ### Building for production
 
-JS Bin's build process uses Grunt, so assuming you've cloned a copy, you will need the dev dependancies and the grunt cli:
+JS Bin's build process uses Grunt, so assuming you've cloned a copy, you will need the dev dependencies and the grunt cli:
 
     $ npm install -g grunt-cli
     $ npm install --dev

--- a/docs/when-do-revisions-change.md
+++ b/docs/when-do-revisions-change.md
@@ -2,7 +2,7 @@
 
 Let's say you've started afresh on jsbin.com. You're welcomed with either your own saved template or the default empty HTML page.
 
-**As soon as you start typing** you recieve your own URL and revision (revision 1) for that code. Let's say that url is `jsbin.com/abcde/1/`
+**As soon as you start typing** you receive your own URL and revision (revision 1) for that code. Let's say that url is `jsbin.com/abcde/1/`
 
 If you continue to type, all your changes are saved under revision 1 of `abcde`.
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -44,7 +44,7 @@ console.log('Config from %s', localconfig);
 //       'host': 'localhost:3300'
 //     }
 //   }
-// can be overriden with the following environment variable set
+// can be overridden with the following environment variable set
 // JSBIN_URL_HOST=my.url.com
 //
 //

--- a/lib/custom.js
+++ b/lib/custom.js
@@ -61,7 +61,7 @@ if (config.whiteLabel) {
     }
 
     defaults.forEach(function (ext) {
-      // skip this extention if it's already in the config
+      // skip this extension if it's already in the config
 
       var key = ext === 'js' ? 'javascript' : ext;
 

--- a/lib/email/README.md
+++ b/lib/email/README.md
@@ -37,7 +37,7 @@ createEmail({
 ## `sendEmail`
 
 This function returns a promise, which you can use to check for the success or error of the email being sent.
-This function takes an object which you can create yourself but it is reccomended that you pass it the return
+This function takes an object which you can create yourself but it is recommended that you pass it the return
 value of a call to `createEmail`
 
 # Email

--- a/lib/features.js
+++ b/lib/features.js
@@ -120,7 +120,7 @@ var flags = {
   // info/hover card with details of bin and streaming info
   infocard: true, // live July 13, 2014
 
-  // seperate account management pages
+  // separate account management pages
   accountPages: true, // live 2014-05-27
 
   // use SSL for sign in

--- a/lib/handlers/bin.js
+++ b/lib/handlers/bin.js
@@ -2112,7 +2112,7 @@ module.exports = Observable.extend({
           return res.status(500).send(error);
         }
 
-        req.flash(req.flash.INFO, 'Successfully transfered to ' + user.name);
+        req.flash(req.flash.INFO, 'Successfully transferred to ' + user.name);
         res.send(200);
       });
     });

--- a/lib/handlers/session.js
+++ b/lib/handlers/session.js
@@ -742,7 +742,7 @@ module.exports = Observable.extend({
     );
   },
 
-  // Handle custom errors raised by passport-github when recieving an invalid
+  // Handle custom errors raised by passport-github when receiving an invalid
   // code parameter to the callback url eg: /auth/github/callback?code=foo
   //
   // This will likely occur if a user refreshes or hits the back button on

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -25,7 +25,7 @@ module.exports.createHelpers = function createHelpers(app) {
     // Pre-set the URL used for the runner
     runner: app.set('url runner') + '/runner',
 
-    // Renders the analytics snippet. Accepts a callback that recieves
+    // Renders the analytics snippet. Accepts a callback that receives
     // and error and html object.
     renderAnalytics: function(render, fn) {
       if (typeof render === 'function') {

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -70,7 +70,7 @@ var middleware = module.exports = {
       // However, if we send a flash message before sessions exist
       // i.e in run.js, we store on the req object.
       // the cache object starts on the request, and if it is empty
-      // and a session exists we then move it to teh session.
+      // and a session exists we then move it to the session.
       if (Object.keys(cache).length === 0 && this.session) {
         if (!this.session.flashCache) {
           this.session.flashCache = {};

--- a/lib/processors/fork.js
+++ b/lib/processors/fork.js
@@ -27,7 +27,7 @@ module.exports = function (language, source) {
         resolve(JSON.parse(output));
       } catch (e) {
         reject({
-          ouput: {
+          output: {
             result: '',
             errors: null
           },

--- a/public/js/chrome/app.js
+++ b/public/js/chrome/app.js
@@ -12,7 +12,7 @@ if (/gist\/.*/.test(window.location.pathname)) {
   }
 }
 
-// prevent the app from accidently getting scrolled out of view
+// prevent the app from accidentally getting scrolled out of view
 if (!jsbin.mobile) document.body.onscroll = window.onscroll = function () {
   if (document.body.scrollTop !== 0) {
     window.scrollTo(0,0);

--- a/public/js/chrome/gist.js
+++ b/public/js/chrome/gist.js
@@ -133,7 +133,7 @@ var Gist = (function () { // jshint ignore:line
       console.error(error.stack);
     });
 
-    // return false becuase there's weird even stuff going on. ask @rem.
+    // return false because there's weird even stuff going on. ask @rem.
     return false;
   });
 

--- a/public/js/chrome/infocard.js
+++ b/public/js/chrome/infocard.js
@@ -8,7 +8,7 @@
     /*global spinner, $, jsbin, prettyDate, EventSource, throttle, $document, analytics, throttle*/
     'use strict';
 
-    // don't insert this on embeded views
+    // don't insert this on embedded views
     if (jsbin.embed) {
       return;
     }

--- a/public/js/editors/defs.js
+++ b/public/js/editors/defs.js
@@ -84,7 +84,7 @@ ternBasicDefs[0] = ({
       "toLocaleString": {
         "!type": "fn() -> string",
         "!url": "https://developer.mozilla.org/en-US/docs/JavaScript/Reference/Global_Objects/Object/toLocaleString",
-        "!doc": "Returns a string representing the object. This method is meant to be overriden by derived objects for locale-specific purposes."
+        "!doc": "Returns a string representing the object. This method is meant to be overridden by derived objects for locale-specific purposes."
       },
       "valueOf": {
         "!type": "fn() -> number",

--- a/public/js/editors/editors.js
+++ b/public/js/editors/editors.js
@@ -487,7 +487,7 @@ var panelInit = {
   html: function () {
     var init = function () {
       // set cursor position on first blank line
-      // 1. read all the inital lines
+      // 1. read all the initial lines
       var lines = this.editor.getValue().split('\n'),
           blank = -1;
       lines.forEach(function (line, i) {

--- a/public/js/login.js
+++ b/public/js/login.js
@@ -75,7 +75,7 @@
 
     // fromPopstate is true when we call click in handlePopstateChanges
     // If a user navigated back, to register, it would then set pushState
-    // to register, leaving teh user stuck on that page.
+    // to register, leaving the user stuck on that page.
     if (!fromPopstate && pushState) {
       event.preventDefault();
       pushState(path);

--- a/public/js/processors/processor.js
+++ b/public/js/processors/processor.js
@@ -149,7 +149,7 @@ var processors = jsbin.processors = (function () {
       return extendFn(proxyCallback, processorData);
     };
 
-    // Processor fucntion also has the important data on it
+    // Processor function also has the important data on it
     return extendFn(loadProcessor, processorData);
   };
 

--- a/public/js/render/console.js
+++ b/public/js/render/console.js
@@ -586,7 +586,7 @@ var jsconsole = {
     } else if (data.type && data.type == 'info') {
       window.top.info(data.response);
     } else {
-      if (data.cmd.indexOf('console.log') === -1) data.response = data.response.substr(1, data.response.length - 2); // fiddle to remove the [] around the repsonse
+      if (data.cmd.indexOf('console.log') === -1) data.response = data.response.substr(1, data.response.length - 2); // fiddle to remove the [] around the response
       echo(data.cmd);
       log(data.response, 'response');
     }

--- a/public/js/runner/proxy-console.js
+++ b/public/js/runner/proxy-console.js
@@ -54,7 +54,7 @@ var proxyConsole = (function () {
 
       // If the browner supports it, use the browser console but ignore _raw,
       // as _raw should only go to the proxy console.
-      // Ignore clear if it doesn't exist as it's beahviour is different than
+      // Ignore clear if it doesn't exist as it's behaviour is different than
       // log and we let it fallback to jsconsole for the panel and to nothing
       // for the browser console
       if (window.console) {

--- a/views/report.html
+++ b/views/report.html
@@ -12,7 +12,7 @@
           <h1>Report Abuse</h1>
           <div class="bubble">
             <p>Thanks for flagging that for me. I'll investigate things a bit
-            more and take any appropiate action.</p>
+            more and take any appropriate action.</p>
             <p>If you want to add more details, please add it to the <a href="http://github.com/jsbin/jsbin/issues">issues page</a> and include the url to this bin.</p>
           </div>
       </div>


### PR DESCRIPTION
```
jsbin/TODO.md:41:59: "heirachy" is a misspelling of "hierarchy"
jsbin/docs/ie8.md:17:93: "yeild" is a misspelling of "yield"
jsbin/docs/post.md:40:115: "compatability" is a misspelling of "compatibility"
jsbin/docs/post.md:50:179: "recieved" is a misspelling of "received"
jsbin/docs/running-your-own-jsbin.md:86:91: "dependancies" is a misspelling of "dependencies"
jsbin/docs/when-do-revisions-change.md:5:36: "recieve" is a misspelling of "receive"
jsbin/lib/config.js:47:10: "overriden" is a misspelling of "overridden"
jsbin/lib/custom.js:64:19: "extention" is a misspelling of "extension"
jsbin/lib/email/README.md:40:70: "reccomended" is a misspelling of "recommended"
jsbin/lib/features.js:123:5: "seperate" is a misspelling of "separate"
jsbin/lib/handlers/bin.js:2115:48: "transfered" is a misspelling of "transferred"
jsbin/lib/handlers/session.js:745:57: "recieving" is a misspelling of "receiving"
jsbin/lib/helpers.js:28:62: "recieves" is a misspelling of "receives"
jsbin/lib/middleware.js:73:49: "teh" is a misspelling of "the"
jsbin/lib/processors/fork.js:30:10: "ouput" is a misspelling of "output"
jsbin/public/js/chrome/app.js:15:24: "accidently" is a misspelling of "accidentally"
jsbin/public/js/chrome/gist.js:136:20: "becuase" is a misspelling of "because"
jsbin/public/js/chrome/infocard.js:11:28: "embeded" is a misspelling of "embedded"
jsbin/public/js/editors/defs.js:87:86: "overriden" is a misspelling of "overridden"
jsbin/public/js/editors/editors.js:490:25: "inital" is a misspelling of "initial"
jsbin/public/js/login.js:78:28: "teh" is a misspelling of "the"
jsbin/public/js/processors/processor.js:152:17: "fucntion" is a misspelling of "function"
jsbin/public/js/render/console.js:589:155: "repsonse" is a misspelling of "response"
jsbin/public/js/runner/proxy-console.js:57:50: "beahviour" is a misspelling of "behaviour"
jsbin/views/report.html:15:30: "appropiate" is a misspelling of "appropriate"
```