### PR TITLE
Add EventEmitter3 to list of libraries

### DIFF
--- a/public/js/editors/libraries.js
+++ b/public/js/editors/libraries.js
@@ -635,6 +635,10 @@ var libraries = [
     'label': 'TwitterLib'
   },
   {
+    'url': 'https://unpkg.com/eventemitter3@latest/umd/eventemitter3.min.js',
+    'label': 'EventEmitter3'
+  },
+  {
     'url': '//jashkenas.github.io/underscore/underscore-min.js',
     'label': 'underscore'
   },


### PR DESCRIPTION
This PR adds the current stable version of [EventEmitter3](https://github.com/primus/eventemitter3) to the list of libraries.