### PR TITLE
Preventing main container from wrapping under ea banner

### DIFF
--- a/public/css/mobile.css
+++ b/public/css/mobile.css
@@ -15,7 +15,7 @@ html.debug:before {
 main {
   display: block;
   position: relative;
-  height: 100%;
+  height: calc(100% - 43px);
 }
 
 .toppanel main {


### PR DESCRIPTION
Right now, the ethical ads bar floats in front of the editor
This prevents users from being able to see the last lines of their code
![image](https://user-images.githubusercontent.com/21046709/89325940-862fcd80-d657-11ea-9437-1b5993335a0f.png)


With `calc` in css (notice you can see the bottom of the scroll bars
![image](https://user-images.githubusercontent.com/21046709/89325851-639db480-d657-11ea-8602-f2f46f8a9a7b.png)



43 px because
* .ea-placement has `10px` + `12px` padding on top/bottom
* .ea-text has a size of `14px` plus a 1.5 line height (`7px`)
* 10 + 12 + 14 + 7 = 43
