### PR TITLE
Prevent iFrame-Based Open-Redirection

### DIFF
--- a/views/index.html
+++ b/views/index.html
@@ -44,7 +44,7 @@
 {{#unless embed}}
 <script>
 if(top != self) {
-  window.location = location.pathname.split('/').slice(0, -1).concat(['embed']).join('/') + (location.search ? location.search : '');
+  window.location = window.location.origin + location.pathname.split('/').slice(0, -1).concat(['embed']).join('/') + (location.search ? location.search : '');
   document.write('<' + '!--');
 }
 </script>


### PR DESCRIPTION
In the current version of JSBin, there exists a vulnerability where if the path is `https://jsbin.com//evil.com/` within an iFrame, the page redirects to `//evil.com/embed?...`, potentially leading to an Open-Redirect exploit. This PR addresses this issue by modifying the redirection mechanism to prepend `window.location.origin`, thus ensuring that the redirection stays within the JSBin domain and mitigating the risk of Open-Redirect vulnerabilities.